### PR TITLE
refactoring navigation

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -60,18 +60,20 @@ export class Editor {
         this.module = module;
     }
 
-    focusSelection(selection: monaco.Selection, code: CodeConstruct = null) {
-        if (selection.startColumn == selection.endColumn) {
-            this.monaco.setPosition(new monaco.Position(selection.startLineNumber, selection.startColumn));
-        } else {
-            this.cursor.setSelection(selection, code);
-            this.monaco.setSelection(selection);
-        }
+    focusSelection() {
+        // if (selection.startColumn == selection.endColumn) {
+        //     this.monaco.setPosition(new monaco.Position(selection.startLineNumber, selection.startColumn));
+        // } else {
+        //     this.cursor.setSelection(selection, code);
+        //     this.monaco.setSelection(selection);
+        // }
+
+        const context = this.module.focus.getContext();
 
         if (this.module.menuController.isMenuOpen()) this.module.menuController.removeMenus();
 
-        const validInserts = this.module.getAllValidInsertsList(this.module.focusedNode);
-
+        //disable toolbox buttons based on available inserts
+        const validInserts = this.module.getAllValidInsertsList(context.token);
         Object.keys(ConstructKeys).forEach((construct) => {
             if (constructToToolboxButton.has(ConstructKeys[construct])) {
                 if (validInserts.indexOf(ConstructKeys[construct]) == -1) {

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -67,30 +67,9 @@ export class Editor {
         //     this.cursor.setSelection(selection, code);
         //     this.monaco.setSelection(selection);
         // }
-
         const context = this.module.focus.getContext();
 
-        if (this.module.menuController.isMenuOpen()) this.module.menuController.removeMenus();
 
-        //disable toolbox buttons based on available inserts
-        /*const validInserts = this.module.getAllValidInsertsList(context.token);
-        Object.keys(ConstructKeys).forEach((construct) => {
-            if (constructToToolboxButton.has(ConstructKeys[construct])) {
-                if (validInserts.indexOf(ConstructKeys[construct]) == -1) {
-                    const button = document.getElementById(
-                        constructToToolboxButton.get(ConstructKeys[construct])
-                    ) as HTMLButtonElement;
-                    button.disabled = true;
-                    button.classList.add("disabled");
-                } else {
-                    const button = document.getElementById(
-                        constructToToolboxButton.get(ConstructKeys[construct])
-                    ) as HTMLButtonElement;
-                    button.disabled = false;
-                    button.classList.remove("disabled");
-                }
-            }
-        });*/
     }
 
     getLineEl(ln: number) {

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -73,7 +73,7 @@ export class Editor {
         if (this.module.menuController.isMenuOpen()) this.module.menuController.removeMenus();
 
         //disable toolbox buttons based on available inserts
-        const validInserts = this.module.getAllValidInsertsList(context.token);
+        /*const validInserts = this.module.getAllValidInsertsList(context.token);
         Object.keys(ConstructKeys).forEach((construct) => {
             if (constructToToolboxButton.has(ConstructKeys[construct])) {
                 if (validInserts.indexOf(ConstructKeys[construct]) == -1) {
@@ -90,7 +90,7 @@ export class Editor {
                     button.classList.remove("disabled");
                 }
             }
-        });
+        });*/
     }
 
     getLineEl(ln: number) {

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -115,7 +115,11 @@ export class Editor {
     }
 
     executeEdits(range: monaco.Range, code: CodeConstruct, overwrite: string = null) {
-        const text = overwrite || code.getRenderText();
+        let text = overwrite;
+
+        if (overwrite == null)
+            text = code.getRenderText();
+
         this.monaco.executeEdits("module", [{ range: range, text, forceMoveMarkers: true }]);
 
         this.addHoles(code);

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -118,9 +118,9 @@ export class EventHandler {
     }
 
     getKeyAction(e: KeyboardEvent) {
-        const curPos = this.module.editor.monaco.getPosition();
-        const inTextEditMode = this.module.focus.isTextEditable();
         const context = this.module.focus.getContext();
+        const curPos = this.module.editor.monaco.getPosition();
+        const inTextEditMode = this.module.focus.isTextEditable(context);
 
         switch (e.key) {
             case KeyPress.ArrowUp:
@@ -351,7 +351,7 @@ export class EventHandler {
             case EditAction.InsertChar: {
                 const cursorPos = this.module.editor.monaco.getPosition();
                 const selectedText = this.module.editor.monaco.getSelection();
-                const token = this.module.focus.getTextEditableItem();
+                const token = this.module.focus.getTextEditableItem(context);
                 let newText = "";
 
                 if (token.getEditableText() == "   ") {
@@ -430,7 +430,7 @@ export class EventHandler {
             case EditAction.DeleteNextChar: {
                 const cursorPos = this.module.editor.monaco.getPosition();
                 const selectedText = this.module.editor.monaco.getSelection();
-                const token = this.module.focus.getTextEditableItem();
+                const token = this.module.focus.getTextEditableItem(context);
 
                 let newText = "";
 

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -929,30 +929,6 @@ export class EventHandler {
 
                 break;
 
-            case "add-test-array":
-                const varAssignStmt = new ast.VarAssignmentStmt("arr");
-                const listExpr = new ast.ListLiteralExpression();
-                listExpr.insertListItem(1, 30);
-                listExpr.insertListItem(1, 60);
-                listExpr.insertListItem(1, 80);
-                listExpr.insertListItem(1, 20);
-                listExpr.insertListItem(1, 50);
-                listExpr.insertListItem(1, 100);
-                listExpr.insertListItem(1, 10);
-                listExpr.insertListItem(1, 70);
-                listExpr.insertListItem(1, 90);
-                listExpr.insertListItem(1, 40);
-
-                varAssignStmt.replaceValue(listExpr);
-
-                this.module.addVariableButtonToToolbox(varAssignStmt);
-                this.module.scope.references.push(new ast.Reference(varAssignStmt, this.module.scope));
-                varAssignStmt.updateButton();
-
-                this.module.insert(varAssignStmt);
-
-                break;
-
             case "add-split-method-call-btn":
                 this.module.insert(
                     new ast.MethodCallExpr(

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -141,11 +141,10 @@ export class EventHandler {
                     // or
                     // at selected an empty editable identifier
                     // => navigate to the previous token this.focus.navigateLeft();
-
                     if (
                         context.tokenToRight instanceof ast.EditableTextTkn ||
                         context.tokenToRight instanceof ast.IdentifierTkn ||
-                        (context.token.isEmpty && context.selected)
+                        (context.token?.isEmpty && context.selected)
                     )
                         return EditAction.SelectPrevToken;
                     if (e.shiftKey && e.ctrlKey) return EditAction.SelectToStart;
@@ -166,7 +165,7 @@ export class EventHandler {
                     if (
                         context.tokenToLeft instanceof ast.EditableTextTkn ||
                         context.tokenToLeft instanceof ast.IdentifierTkn ||
-                        (context.token.isEmpty && context.selected)
+                        (context.token?.isEmpty && context.selected)
                     ) {
                         return EditAction.SelectNextToken;
                     }

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -143,6 +143,7 @@ export class EventHandler {
                     // at selected an empty editable identifier
                     // => navigate to the previous token this.focus.navigateLeft();
                     if (
+                        (context.tokenToLeft instanceof ast.IdentifierTkn && context.tokenToRight.isEmpty) ||
                         context.tokenToRight instanceof ast.EditableTextTkn ||
                         context.tokenToRight instanceof ast.IdentifierTkn ||
                         (context.token?.isEmpty && context.selected)
@@ -163,7 +164,11 @@ export class EventHandler {
                     // at selected an empty editable identifier
                     // => navigate to the previous token this.focus.navigateRight();
 
+                    // also if we're right before an editable item and need to select it with this new arrow-right key press.
                     if (
+                        ((context.tokenToRight instanceof ast.IdentifierTkn ||
+                            context.tokenToRight instanceof ast.EditableTextTkn) &&
+                            context.tokenToRight.isEmpty) ||
                         context.tokenToLeft instanceof ast.EditableTextTkn ||
                         context.tokenToLeft instanceof ast.IdentifierTkn ||
                         (context.token?.isEmpty && context.selected)

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -740,25 +740,23 @@ export class EventHandler {
     onButtonDown(id: string) {
         switch (id) {
             case "add-var-btn":
-                if (!(document.getElementById("add-var-btn") as HTMLButtonElement).disabled) {
-                    this.module.insert(new ast.VarAssignmentStmt());
-                }
+                this.pressButton(id, (() => {this.module.insert(new ast.VarAssignmentStmt())}).bind(this));
 
                 break;
 
             case "add-print-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.FunctionCallStmt(
                         "print",
                         [new ast.Argument(ast.DataType.Any, "item", false)],
                         ast.DataType.Void
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-randint-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.FunctionCallStmt(
                         "randint",
                         [
@@ -767,12 +765,12 @@ export class EventHandler {
                         ],
                         ast.DataType.Number
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-range-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.FunctionCallStmt(
                         "range",
                         [
@@ -781,181 +779,181 @@ export class EventHandler {
                         ],
                         ast.DataType.List
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-len-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.FunctionCallStmt(
                         "len",
                         [new ast.Argument(ast.DataType.List, "list", false)],
                         ast.DataType.Number
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-str-btn":
-                this.module.insert(new ast.LiteralValExpr(ast.DataType.String));
+                this.pressButton(id, (() => {this.module.insert(new ast.LiteralValExpr(ast.DataType.String))}).bind(this));
 
                 break;
 
             case "add-num-btn":
-                this.module.insert(new ast.LiteralValExpr(ast.DataType.Number, "0"));
+                this.pressButton(id, (() => {this.module.insert(new ast.LiteralValExpr(ast.DataType.Number, "0"))}).bind(this));
 
                 break;
 
             case "add-true-btn":
-                this.module.insert(new ast.LiteralValExpr(ast.DataType.Boolean, "True"));
+                this.pressButton(id, (() => {this.module.insert(new ast.LiteralValExpr(ast.DataType.Boolean, "True"))}).bind(this));
 
                 break;
 
             case "add-false-btn":
-                this.module.insert(new ast.LiteralValExpr(ast.DataType.Boolean, "False"));
+                this.pressButton(id, (() => {this.module.insert(new ast.LiteralValExpr(ast.DataType.Boolean, "False"))}).bind(this));
 
                 break;
 
             case "add-bin-add-expr-btn":
-                this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Add, ast.DataType.Any));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Add, ast.DataType.Any))}).bind(this));
 
                 break;
 
             case "add-bin-sub-expr-btn":
-                this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Subtract, ast.DataType.Any));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Subtract, ast.DataType.Any))}).bind(this));
 
                 break;
 
             case "add-bin-mul-expr-btn":
-                this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Multiply, ast.DataType.Any));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Multiply, ast.DataType.Any))}).bind(this));
 
                 break;
 
             case "add-bin-div-expr-btn":
-                this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Divide, ast.DataType.Any));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryOperatorExpr(ast.BinaryOperator.Divide, ast.DataType.Any))}).bind(this));
 
                 break;
 
             case "add-bin-and-expr-btn":
-                this.module.insert(new ast.BinaryBoolOperatorExpr(ast.BoolOperator.And));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryBoolOperatorExpr(ast.BoolOperator.And))}).bind(this));
 
                 break;
 
             case "add-bin-or-expr-btn":
-                this.module.insert(new ast.BinaryBoolOperatorExpr(ast.BoolOperator.Or));
+                this.pressButton(id, (() => {this.module.insert(new ast.BinaryBoolOperatorExpr(ast.BoolOperator.Or))}).bind(this));
 
                 break;
 
             case "add-unary-not-expr-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.UnaryOperatorExpr(ast.UnaryOp.Not, ast.DataType.Boolean, ast.DataType.Boolean)
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-comp-eq-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.Equal));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.Equal))}).bind(this));
 
                 break;
 
             case "add-comp-neq-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.NotEqual));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.NotEqual))}).bind(this));
 
                 break;
 
             case "add-comp-lt-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.LessThan));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.LessThan))}).bind(this));
 
                 break;
 
             case "add-comp-lte-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.LessThanEqual));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.LessThanEqual))}).bind(this));
 
                 break;
 
             case "add-comp-gt-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.GreaterThan));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.GreaterThan))}).bind(this));
 
                 break;
 
             case "add-comp-gte-expr-btn":
-                this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.GreaterThanEqual));
+                this.pressButton(id, (() => {this.module.insert(new ast.ComparatorExpr(ast.ComparatorOp.GreaterThanEqual))}).bind(this));
 
                 break;
 
             case "add-while-expr-btn":
-                this.module.insert(new ast.WhileStatement());
+                this.pressButton(id, (() => {this.module.insert(new ast.WhileStatement())}).bind(this));
 
                 break;
 
             case "add-if-expr-btn":
-                this.module.insert(new ast.IfStatement());
+                this.pressButton(id, (() => {this.module.insert(new ast.IfStatement())}).bind(this));
 
                 break;
 
             case "add-elif-expr-btn":
-                this.module.insert(new ast.ElseStatement(true));
+                this.pressButton(id, (() => {this.module.insert(new ast.ElseStatement(true))}).bind(this));
 
                 break;
 
             case "add-else-expr-btn":
-                this.module.insert(new ast.ElseStatement(false));
+                this.pressButton(id, (() => {this.module.insert(new ast.ElseStatement(false))}).bind(this));
 
                 break;
 
             case "add-for-expr-btn":
-                this.module.insert(new ast.ForStatement());
+                this.pressButton(id, (() => {this.module.insert(new ast.ForStatement())}).bind(this));
 
                 break;
 
             case "add-list-literal-btn":
-                this.module.insert(new ast.ListLiteralExpression());
+                this.pressButton(id, (() => {this.module.insert(new ast.ListLiteralExpression())}).bind(this));
 
                 break;
 
             case "add-list-item-btn":
-                this.module.insertListItem();
+                this.pressButton(id, (() => {this.module.insertListItem()}).bind(this));
 
                 break;
 
             case "add-list-append-stmt-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.MethodCallStmt("append", [new ast.Argument(ast.DataType.Any, "object", false)])
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-list-index-btn":
-                this.module.insert(new ast.MemberCallStmt(ast.DataType.Any));
+                this.pressButton(id, (() => {this.module.insert(new ast.MemberCallStmt(ast.DataType.Any))}).bind(this));
 
                 break;
 
             case "add-split-method-call-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.MethodCallExpr(
                         "split",
                         [new ast.Argument(ast.DataType.String, "sep", false)],
                         ast.DataType.List,
                         ast.DataType.String
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-join-method-call-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.MethodCallExpr(
                         "join",
                         [new ast.Argument(ast.DataType.List, "items", false)],
                         ast.DataType.String,
                         ast.DataType.String
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-replace-method-call-btn":
-                this.module.insert(
+                this.pressButton(id, (() => { this.module.insert(
                     new ast.MethodCallExpr(
                         "replace",
                         [
@@ -965,24 +963,24 @@ export class EventHandler {
                         ast.DataType.String,
                         ast.DataType.String
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-find-method-call-btn":
-                this.module.insert(
+                this.pressButton(id, (() => {this.module.insert(
                     new ast.MethodCallExpr(
                         "find",
                         [new ast.Argument(ast.DataType.String, "item", false)],
                         ast.DataType.Number,
                         ast.DataType.String
                     )
-                );
+                )}).bind(this));
 
                 break;
 
             case "add-list-elem-assign-btn":
-                this.module.insert(new ast.ListElementAssignment());
+                this.pressButton(id, (() => {this.module.insert(new ast.ListElementAssignment())}).bind(this));
 
                 break;
 
@@ -996,5 +994,11 @@ export class EventHandler {
 
     onDidScrollChange(e) {
         this.module.editor.scrollOffsetTop = e.scrollTop;
+    }
+
+    private pressButton(buttonId: string, callback: Function){
+        if (!(document.getElementById(buttonId) as HTMLButtonElement).disabled) {
+            callback();
+        }
     }
 }

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -326,7 +326,7 @@ export class EventHandler {
 
         const context = this.module.focus.getContext();
 
-        let focusedNode = this.module.focus.onEmptyLine() ? context.lineStatement : context?.token;
+        let focusedNode = context.token && context.selected ? context.token : context.lineStatement;
 
         switch (action) {
             case EditAction.InsertEmptyLine: {
@@ -534,9 +534,15 @@ export class EventHandler {
             }
 
             case EditAction.MoveCursorLeft:
+               // Hole.disableEditableHoleHighlights();
+               // this.module.focus.highlightTextEditableHole();
+
                 break;
 
             case EditAction.MoveCursorRight:
+               // Hole.disableEditableHoleHighlights();
+               // this.module.focus.highlightTextEditableHole();
+
                 break;
 
             case EditAction.SelectLeft:
@@ -583,14 +589,14 @@ export class EventHandler {
                 break;
 
             case EditAction.CompleteIntLiteral:
-                this.module.constructCompleter.completeLiteralConstruct(DataType.Number);
+                this.module.constructCompleter.completeLiteralConstruct(DataType.Number, e.browserEvent.key);
 
                 e.preventDefault();
                 e.stopPropagation();
                 break;
 
             case EditAction.CompleteStringLiteral:
-                this.module.constructCompleter.completeLiteralConstruct(DataType.String);
+                this.module.constructCompleter.completeLiteralConstruct(DataType.String, "");
 
                 e.preventDefault();
                 e.stopPropagation();
@@ -729,9 +735,6 @@ export class EventHandler {
 
     onMouseDown(e) {
         this.module.focus.navigatePos(e.target.position);
-
-        Hole.disableEditableHoleHighlights();
-        this.module.focus.highlightTextEditableHole();
     }
 
     onButtonDown(id: string) {
@@ -799,7 +802,7 @@ export class EventHandler {
                 break;
 
             case "add-num-btn":
-                this.module.insert(new ast.LiteralValExpr(ast.DataType.Number));
+                this.module.insert(new ast.LiteralValExpr(ast.DataType.Number, "0"));
 
                 break;
 

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -5,7 +5,6 @@ import { ErrorMessage } from "../notification-system/error-msg-generator";
 import * as keywords from "../syntax-tree/keywords";
 import { BinaryOperator, DataType } from "../syntax-tree/ast";
 import { ConstructKeys, Util } from "../utilities/util";
-import { NavigationFocus } from "./focus";
 
 export enum KeyPress {
     // navigation:
@@ -47,16 +46,16 @@ export enum KeyPress {
 }
 
 export enum EditAction {
-    Copy, // TODO: could use default or navigator.clipboard.writeText()
-    Paste, // TODO: check navigator.clipboard.readText()
+    Copy, // TODO: NYI: could use default or navigator.clipboard.writeText()
+    Paste, // TODO: NYI: check navigator.clipboard.readText()
 
     Undo,
     Redo,
 
     MoveCursorLeft,
     MoveCursorRight,
-    MoveCursorStart, // TODO
-    MoveCursorEnd, // TODO
+    MoveCursorStart, // TODO: NYI
+    MoveCursorEnd, // TODO: NYI
 
     DeleteNextChar,
     DeletePrevChar,
@@ -66,8 +65,8 @@ export enum EditAction {
 
     SelectLeft,
     SelectRight,
-    SelectToStart, // TODO
-    SelectToEnd, // TODO
+    SelectToStart, // TODO: NYI
+    SelectToEnd, // TODO: NYI
 
     SelectNextToken,
     SelectPrevToken,
@@ -107,7 +106,7 @@ export enum EditAction {
     OpenSubMenu,
     CloseSubMenu,
 
-    //TODO: Remove later
+    //TODO: Remove later (for the continuos menu with categories)
     OpenValidInsertMenuSingleLevel,
 }
 
@@ -118,24 +117,10 @@ export class EventHandler {
         this.module = module;
     }
 
-    private update(navFocus: NavigationFocus) {
-		if (navFocus.token != null && navFocus.select) this.setFocusedNode(navFocus.token);
-		else if (!navFocus.select)
-			this.module.focusedNode = navFocus.token;
-	}
-
-    setFocusedNode(code: ast.CodeConstruct) {
-        this.module.focusedNode.notify(ast.CallbackType.loseFocus);
-
-        this.module.focusedNode = code;
-		this.module.editor.focusSelection(this.module.focusedNode.getSelection());
-
-        code.notify(ast.CallbackType.focus);
-    }
-
     getKeyAction(e: KeyboardEvent) {
         const curPos = this.module.editor.monaco.getPosition();
         const inTextEditMode = this.module.focus.isTextEditable();
+        const context = this.module.focus.getContext();
 
         switch (e.key) {
             case KeyPress.ArrowUp:
@@ -152,8 +137,7 @@ export class EventHandler {
                 if (!inTextEditMode && this.module.menuController.isMenuOpen()) return EditAction.CloseSubMenu;
 
                 if (inTextEditMode) {
-                    if (curPos.column == (this.module.focusedNode as ast.Token).left) return EditAction.SelectPrevToken;
-
+                    if (this.module.focus.onEndOrBeginningOfToken()) return EditAction.SelectPrevToken;
                     if (e.shiftKey && e.ctrlKey) return EditAction.SelectToStart;
                     else if (e.shiftKey) return EditAction.SelectLeft;
                     else if (e.ctrlKey) return EditAction.MoveCursorStart;
@@ -164,10 +148,7 @@ export class EventHandler {
                 if (!inTextEditMode && this.module.menuController.isMenuOpen()) return EditAction.OpenSubMenu;
 
                 if (inTextEditMode) {
-                    if (
-                        curPos.column == (this.module.focusedNode as ast.Token).right ||
-                        (this.module.focusedNode as ast.Token).text == "   "
-                    ) {
+                    if (this.module.focus.onEndOrBeginningOfToken() || (context.token.isEmpty && context.selected)) {
                         return EditAction.SelectNextToken;
                     }
 
@@ -208,9 +189,9 @@ export class EventHandler {
             case KeyPress.Enter:
                 if (this.module.menuController.isMenuOpen()) return EditAction.SelectMenuSuggestion;
 
-                const curLine = this.module.locateStatement(curPos);
                 const curSelection = this.module.editor.monaco.getSelection();
-                const parent = this.module.focusedNode.getParentStatement().rootNode;
+                const curStatement = this.module.focus.getFocusedStatement();
+                const parent = curStatement.rootNode;
                 let leftPosToCheck = 1;
 
                 if (parent instanceof ast.Statement && parent.body.length > 0) {
@@ -219,7 +200,7 @@ export class EventHandler {
                 }
 
                 if (curSelection.startColumn == curSelection.endColumn) {
-                    if (curPos.column == leftPosToCheck || curPos.column == curLine.right)
+                    if (curPos.column == leftPosToCheck || curPos.column == curStatement.right)
                         return EditAction.InsertEmptyLine;
                 }
 
@@ -312,13 +293,17 @@ export class EventHandler {
                     return EditAction.None;
                 }
         }
-    }
+    }    
 
     onKeyDown(e) {
         const action = this.getKeyAction(e.browserEvent);
         const selection = this.module.editor.monaco.getSelection();
         let suggestions = [];
 
+        const context = this.module.focus.getContext();
+
+        let focusedNode = this.module.focus.onEmptyLine() ? context.lineStatement : context?.token;
+        
         switch (action) {
             case EditAction.InsertEmptyLine: {
                 this.module.insertEmptyLine();
@@ -329,7 +314,7 @@ export class EventHandler {
             }
 
             case EditAction.SelectPrevToken: {
-                this.update(this.module.focus.navigateLeft());
+                this.module.focus.navigateLeft();
 
                 e.preventDefault();
                 e.stopPropagation();
@@ -337,7 +322,7 @@ export class EventHandler {
             }
 
             case EditAction.SelectNextToken: {
-                this.update(this.module.focus.navigateRight());
+                this.module.focus.navigateRight();
 
                 e.preventDefault();
                 e.stopPropagation();
@@ -346,21 +331,8 @@ export class EventHandler {
 
             case EditAction.InsertChar: {
                 const cursorPos = this.module.editor.monaco.getPosition();
-                const selectedText = this.module.editor.monaco.getSelection();
-
-                let token: ast.TextEditable;
-
-                if (
-                    this.module.focusedNode instanceof ast.IdentifierTkn ||
-                    this.module.focusedNode instanceof ast.EditableTextTkn
-                ) {
-                    token = this.module.focusedNode;
-                } else {
-                    throw new Error(
-                        "Trying to insert-char at an incorrect token or with an incorrect isTextEditable value."
-                    );
-                }
-
+                const selectedText = this.module.editor.monaco.getSelection();                
+                const token = this.module.focus.getTextEditableItem();
                 let newText = "";
 
                 if (token.getEditableText() == "   ") {
@@ -369,7 +341,7 @@ export class EventHandler {
                 } else {
                     const curText = token.getEditableText().split("");
                     curText.splice(
-                        cursorPos.column - this.module.focusedNode.left,
+                        cursorPos.column - token.getLeft(),
                         Math.abs(selectedText.startColumn - selectedText.endColumn),
                         e.browserEvent.key
                     );
@@ -377,7 +349,8 @@ export class EventHandler {
                     newText = curText.join("");
                 }
 
-                if (this.module.focusedNode instanceof ast.IdentifierTkn) {
+                // TODO: this.module.focus.isInsideIdentifier()
+                if (context.selected && context?.token instanceof ast.IdentifierTkn) {
                     let newNotification = false;
 
                     /*TODO: Change this to use the new focus.
@@ -386,14 +359,14 @@ export class EventHandler {
                      */
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
-                            this.module.focusedNode,
+                            context?.token,
                             { identifier: newText },
                             ErrorMessage.identifierIsKeyword
                         );
                         newNotification = true;
                     } else if (Object.keys(keywords.BuiltInFunctions).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
-                            this.module.focusedNode,
+                            context?.token,
                             { identifier: newText },
                             ErrorMessage.identifierIsBuiltInFunc
                         );
@@ -401,13 +374,8 @@ export class EventHandler {
                         newNotification = true;
                     }
 
-                    if (!newNotification && this.module.focusedNode.notification) {
-                        /*TODO: Change to use the new focus
-                         * 
-                         * This needs to use whatever construct is used for the check above. It should not matter whether it is Token, Statement or Expression since
-                         * all of those were a possibility before as well.
-                         */
-                        this.module.notificationSystem.removeNotificationFromConstruct(this.module.focusedNode);
+                    if (!newNotification && context?.token.notification) {
+                        this.module.notificationSystem.removeNotificationFromConstruct(context?.token);
                     }
                 }
 
@@ -443,19 +411,7 @@ export class EventHandler {
             case EditAction.DeleteNextChar: {
                 const cursorPos = this.module.editor.monaco.getPosition();
                 const selectedText = this.module.editor.monaco.getSelection();
-
-                let token: ast.TextEditable;
-
-                if (
-                    this.module.focusedNode instanceof ast.IdentifierTkn ||
-                    this.module.focusedNode instanceof ast.EditableTextTkn
-                ) {
-                    token = this.module.focusedNode;
-                } else {
-                    throw new Error(
-                        "Trying to insert-char at an incorrect token or with an incorrect isTextEditable value."
-                    );
-                }
+                const token = this.module.focus.getTextEditableItem();
 
                 let newText = "";
 
@@ -471,15 +427,15 @@ export class EventHandler {
 
                 curText.splice(
                     Math.min(
-                        cursorPos.column - this.module.focusedNode.left - toDeletePos,
-                        selectedText.startColumn - this.module.focusedNode.left - toDeletePos
+                        cursorPos.column - token.getLeft() - toDeletePos,
+                        selectedText.startColumn - token.getLeft() - toDeletePos
                     ),
                     toDeleteItems
                 );
 
                 newText = curText.join("");
-
-                if (this.module.focusedNode instanceof ast.IdentifierTkn) {
+            
+                if (context.selected && context?.token instanceof ast.IdentifierTkn) {
                     let newNotification = false;
 
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
@@ -488,27 +444,22 @@ export class EventHandler {
                         * This needs to use whatever code construct is used for the check in the if-statement above.
                         */
                         this.module.notificationSystem.addHoverNotification(
-                            this.module.focusedNode,
+                            context?.token,
                             { identifier: newText },
                             ErrorMessage.identifierIsKeyword
                         );
                         newNotification = true;
                     } else if (Object.keys(keywords.BuiltInFunctions).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
-                            this.module.focusedNode,
+                            context?.token,
                             { identifier: newText },
                             ErrorMessage.identifierIsBuiltInFunc
                         );
                         newNotification = true;
                     }
 
-                    if (!newNotification && this.module.focusedNode.notification) {
-                        /*TODO: Change to use the new focus
-                         * 
-                         * This needs to use whatever construct is used for the check above. It should not matter whether it is Token, Statement or Expression since
-                         * all of those were a possibility before as well.
-                         */
-                        this.module.notificationSystem.removeNotificationFromConstruct(this.module.focusedNode);
+                    if (!newNotification && context?.token.notification) {
+                        this.module.notificationSystem.removeNotificationFromConstruct(context?.token);
                     }
                 }
 
@@ -541,7 +492,7 @@ export class EventHandler {
             }
 
             case EditAction.SelectClosestTokenAbove: {
-                this.update(this.module.focus.navigateUp());
+                this.module.focus.navigateUp();
 
                 e.stopPropagation();
                 e.preventDefault();
@@ -550,7 +501,7 @@ export class EventHandler {
             }
 
             case EditAction.SelectClosestTokenBelow: {
-				this.update(this.module.focus.navigateDown());
+				this.module.focus.navigateDown();
 
                 e.stopPropagation();
                 e.preventDefault();
@@ -601,9 +552,6 @@ export class EventHandler {
                 break;
 
             case EditAction.CompleteMultiplication:
-                console.log(this.module.editor.holes);
-                console.log(e);
-
                 this.module.constructCompleter.completeArithmeticConstruct(BinaryOperator.Multiply);
 
                 e.preventDefault();
@@ -632,47 +580,32 @@ export class EventHandler {
                 break;
 
             case EditAction.DisplayGreaterThanSuggestion:
-                suggestions = [ConstructKeys.GreaterThan, ConstructKeys.GreaterThanOrEqual];
-
-                //TODO: Change focus
-                /*
-                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
-                 * getValidInsertsFromSet() will sort it out.
-                 * 
-                 * Might need to make some changes to that method to deal with new selections that are possible though. 
-                 */
-                suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
-                this.module.menuController.buildSingleLevelMenu(
-                    suggestions,
-                    Util.getInstance(this.module).constructActions,
-                    {
-                        left: selection.startColumn * this.module.editor.computeCharWidth(),
-                        top: selection.startLineNumber * this.module.editor.computeCharHeight(),
-                    }
-                );
+                if(this.module.isAbleToInsertComparator(context)){
+                    this.module.menuController.buildSingleLevelMenu(
+                        [ConstructKeys.GreaterThan, ConstructKeys.GreaterThanOrEqual],
+                        Util.getInstance(this.module).constructActions,
+                        {
+                            left: selection.startColumn * this.module.editor.computeCharWidth(),
+                            top: selection.startLineNumber * this.module.editor.computeCharHeight(),
+                        }
+                    );
+                }
 
                 e.preventDefault();
                 e.stopPropagation();
                 break;
 
             case EditAction.DisplayLessThanSuggestion:
-                suggestions = [ConstructKeys.LessThan, ConstructKeys.LessThanOrEqual];
-
-                //TODO: Change focus
-                /*
-                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
-                 * getValidInsertsFromSet() will sort it out.
-                 */
-                suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
-
-                this.module.menuController.buildSingleLevelMenu(
-                    suggestions,
-                    Util.getInstance(this.module).constructActions,
-                    {
-                        left: selection.startColumn * this.module.editor.computeCharWidth(),
-                        top: selection.startLineNumber * this.module.editor.computeCharHeight(),
-                    }
-                );
+                if(this.module.isAbleToInsertComparator(context)){
+                    this.module.menuController.buildSingleLevelMenu(
+                        [ConstructKeys.LessThan, ConstructKeys.LessThanOrEqual],
+                        Util.getInstance(this.module).constructActions,
+                        {
+                            left: selection.startColumn * this.module.editor.computeCharWidth(),
+                            top: selection.startLineNumber * this.module.editor.computeCharHeight(),
+                        }
+                    );
+                }
 
                 e.preventDefault();
                 e.stopPropagation();
@@ -680,13 +613,7 @@ export class EventHandler {
 
             case EditAction.DisplayEqualsSuggestion:
                 suggestions = [ConstructKeys.Equals, ConstructKeys.NotEquals, ConstructKeys.VariableAssignment];
-
-                //TODO: Change focus
-                /*
-                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
-                 * getValidInsertsFromSet() will sort it out.
-                 */
-                suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
+                suggestions = this.module.getValidInsertsFromSet(focusedNode, suggestions);
 
                 this.module.menuController.buildSingleLevelMenu(
                     suggestions,
@@ -704,7 +631,7 @@ export class EventHandler {
             case EditAction.OpenValidInsertMenu:
                 if (!this.module.menuController.isMenuOpen()) {
                     this.module.menuController.buildAvailableInsertsMenu(
-                        this.module.getAllValidInsertsList(this.module.focusedNode),
+                        this.module.getAllValidInsertsList(focusedNode),
                         Util.getInstance(this.module).constructActions,
                         {
                             left: selection.startColumn * this.module.editor.computeCharWidth(),
@@ -720,7 +647,7 @@ export class EventHandler {
             //TODO: Remove later
             case EditAction.OpenValidInsertMenuSingleLevel:
                 if (!this.module.menuController.isMenuOpen()) {
-                    const suggestions = this.module.getAllValidInsertsList(this.module.focusedNode);
+                    const suggestions = this.module.getAllValidInsertsList(focusedNode);
                     this.module.menuController.buildSingleLevelConstructCategoryMenu(suggestions);
                 } else this.module.menuController.removeMenus();
 
@@ -730,36 +657,42 @@ export class EventHandler {
 
             case EditAction.SelectMenuSuggestionAbove:
                 this.module.menuController.focusOptionAbove();
+                
                 e.stopPropagation();
                 e.preventDefault();
                 break;
 
             case EditAction.SelectMenuSuggestionBelow:
                 this.module.menuController.focusOptionBelow();
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
 
             case EditAction.SelectMenuSuggestion:
                 this.module.menuController.selectFocusedOption();
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
 
             case EditAction.CloseValidInsertMenu:
                 this.module.menuController.removeMenus();
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
 
             case EditAction.OpenSubMenu:
                 this.module.menuController.openSubMenu();
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
 
             case EditAction.CloseSubMenu:
                 this.module.menuController.closeSubMenu();
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
@@ -771,7 +704,7 @@ export class EventHandler {
     }
 
     onMouseDown(e) {
-		this.update(this.module.focus.navigatePos(e.target.position));
+		this.module.focus.navigatePos(e.target.position);
     }
 
     onButtonDown(id: string) {

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -374,7 +374,7 @@ export class EventHandler {
                 }
 
                 // TODO: this.module.focus.isInsideIdentifier()
-                if (context.selected && context?.token instanceof ast.IdentifierTkn) {
+                if (focusedNode instanceof ast.IdentifierTkn || context.tokenToLeft instanceof ast.IdentifierTkn || context.tokenToRight instanceof ast.IdentifierTkn) {
                     let newNotification = false;
 
                     /*TODO: Change this to use the new focus.
@@ -383,14 +383,14 @@ export class EventHandler {
                      */
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
-                            context?.token,
+                            focusedNode ?? (context.tokenToLeft ?? context.tokenToRight),
                             { identifier: newText },
                             ErrorMessage.identifierIsKeyword
                         );
                         newNotification = true;
                     } else if (Object.keys(keywords.BuiltInFunctions).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
-                            context?.token,
+                            focusedNode ?? (context.tokenToLeft ?? context.tokenToRight),
                             { identifier: newText },
                             ErrorMessage.identifierIsBuiltInFunc
                         );

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -380,6 +380,10 @@ export class EventHandler {
                 if (this.module.focusedNode instanceof ast.IdentifierTkn) {
                     let newNotification = false;
 
+                    /*TODO: Change this to use the new focus.
+                     * 
+                     * This needs to use whatever code construct is used for the check in the if-statement above.
+                     */
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
                         this.module.notificationSystem.addHoverNotification(
                             this.module.focusedNode,
@@ -398,6 +402,11 @@ export class EventHandler {
                     }
 
                     if (!newNotification && this.module.focusedNode.notification) {
+                        /*TODO: Change to use the new focus
+                         * 
+                         * This needs to use whatever construct is used for the check above. It should not matter whether it is Token, Statement or Expression since
+                         * all of those were a possibility before as well.
+                         */
                         this.module.notificationSystem.removeNotificationFromConstruct(this.module.focusedNode);
                     }
                 }
@@ -474,6 +483,10 @@ export class EventHandler {
                     let newNotification = false;
 
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
+                         /*TODO: Change this to use the new focus.
+                        * 
+                        * This needs to use whatever code construct is used for the check in the if-statement above.
+                        */
                         this.module.notificationSystem.addHoverNotification(
                             this.module.focusedNode,
                             { identifier: newText },
@@ -490,6 +503,11 @@ export class EventHandler {
                     }
 
                     if (!newNotification && this.module.focusedNode.notification) {
+                        /*TODO: Change to use the new focus
+                         * 
+                         * This needs to use whatever construct is used for the check above. It should not matter whether it is Token, Statement or Expression since
+                         * all of those were a possibility before as well.
+                         */
                         this.module.notificationSystem.removeNotificationFromConstruct(this.module.focusedNode);
                     }
                 }
@@ -615,6 +633,14 @@ export class EventHandler {
 
             case EditAction.DisplayGreaterThanSuggestion:
                 suggestions = [ConstructKeys.GreaterThan, ConstructKeys.GreaterThanOrEqual];
+
+                //TODO: Change focus
+                /*
+                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
+                 * getValidInsertsFromSet() will sort it out.
+                 * 
+                 * Might need to make some changes to that method to deal with new selections that are possible though. 
+                 */
                 suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
                 this.module.menuController.buildSingleLevelMenu(
                     suggestions,
@@ -631,6 +657,12 @@ export class EventHandler {
 
             case EditAction.DisplayLessThanSuggestion:
                 suggestions = [ConstructKeys.LessThan, ConstructKeys.LessThanOrEqual];
+
+                //TODO: Change focus
+                /*
+                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
+                 * getValidInsertsFromSet() will sort it out.
+                 */
                 suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
 
                 this.module.menuController.buildSingleLevelMenu(
@@ -648,6 +680,12 @@ export class EventHandler {
 
             case EditAction.DisplayEqualsSuggestion:
                 suggestions = [ConstructKeys.Equals, ConstructKeys.NotEquals, ConstructKeys.VariableAssignment];
+
+                //TODO: Change focus
+                /*
+                 * Can be changed to this.module.focus.getFocusedConstruct(), it does not need a particular type of construct (Token, Statement or Expression),
+                 * getValidInsertsFromSet() will sort it out.
+                 */
                 suggestions = this.module.getValidInsertsFromSet(this.module.focusedNode, suggestions);
 
                 this.module.menuController.buildSingleLevelMenu(

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -5,6 +5,7 @@ import { ErrorMessage } from "../notification-system/error-msg-generator";
 import * as keywords from "../syntax-tree/keywords";
 import { BinaryOperator, DataType } from "../syntax-tree/ast";
 import { ConstructKeys, Util } from "../utilities/util";
+import { Hole } from "./hole";
 
 export enum KeyPress {
     // navigation:
@@ -723,6 +724,9 @@ export class EventHandler {
 
     onMouseDown(e) {
         this.module.focus.navigatePos(e.target.position);
+
+        Hole.disableEditableHoleHighlights();
+        this.module.focus.highlightTextEditableHole();
     }
 
     onButtonDown(id: string) {

--- a/src/editor/events.ts
+++ b/src/editor/events.ts
@@ -137,7 +137,17 @@ export class EventHandler {
                 if (!inTextEditMode && this.module.menuController.isMenuOpen()) return EditAction.CloseSubMenu;
 
                 if (inTextEditMode) {
-                    if (this.module.focus.onEndOrBeginningOfToken()) return EditAction.SelectPrevToken;
+                    // if we're at the beginning of an editable text
+                    // or
+                    // at selected an empty editable identifier
+                    // => navigate to the previous token this.focus.navigateLeft();
+
+                    if (
+                        context.tokenToRight instanceof ast.EditableTextTkn ||
+                        context.tokenToRight instanceof ast.IdentifierTkn ||
+                        (context.token.isEmpty && context.selected)
+                    )
+                        return EditAction.SelectPrevToken;
                     if (e.shiftKey && e.ctrlKey) return EditAction.SelectToStart;
                     else if (e.shiftKey) return EditAction.SelectLeft;
                     else if (e.ctrlKey) return EditAction.MoveCursorStart;
@@ -148,7 +158,16 @@ export class EventHandler {
                 if (!inTextEditMode && this.module.menuController.isMenuOpen()) return EditAction.OpenSubMenu;
 
                 if (inTextEditMode) {
-                    if (this.module.focus.onEndOrBeginningOfToken() || (context.token.isEmpty && context.selected)) {
+                    // if we're at the end of an editable text
+                    // or
+                    // at selected an empty editable identifier
+                    // => navigate to the previous token this.focus.navigateRight();
+
+                    if (
+                        context.tokenToLeft instanceof ast.EditableTextTkn ||
+                        context.tokenToLeft instanceof ast.IdentifierTkn ||
+                        (context.token.isEmpty && context.selected)
+                    ) {
                         return EditAction.SelectNextToken;
                     }
 
@@ -293,7 +312,7 @@ export class EventHandler {
                     return EditAction.None;
                 }
         }
-    }    
+    }
 
     onKeyDown(e) {
         const action = this.getKeyAction(e.browserEvent);
@@ -303,7 +322,7 @@ export class EventHandler {
         const context = this.module.focus.getContext();
 
         let focusedNode = this.module.focus.onEmptyLine() ? context.lineStatement : context?.token;
-        
+
         switch (action) {
             case EditAction.InsertEmptyLine: {
                 this.module.insertEmptyLine();
@@ -331,7 +350,7 @@ export class EventHandler {
 
             case EditAction.InsertChar: {
                 const cursorPos = this.module.editor.monaco.getPosition();
-                const selectedText = this.module.editor.monaco.getSelection();                
+                const selectedText = this.module.editor.monaco.getSelection();
                 const token = this.module.focus.getTextEditableItem();
                 let newText = "";
 
@@ -354,7 +373,7 @@ export class EventHandler {
                     let newNotification = false;
 
                     /*TODO: Change this to use the new focus.
-                     * 
+                     *
                      * This needs to use whatever code construct is used for the check in the if-statement above.
                      */
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
@@ -434,15 +453,15 @@ export class EventHandler {
                 );
 
                 newText = curText.join("");
-            
+
                 if (context.selected && context?.token instanceof ast.IdentifierTkn) {
                     let newNotification = false;
 
                     if (Object.keys(keywords.PythonKeywords).indexOf(newText) > -1) {
-                         /*TODO: Change this to use the new focus.
-                        * 
-                        * This needs to use whatever code construct is used for the check in the if-statement above.
-                        */
+                        /*TODO: Change this to use the new focus.
+                         *
+                         * This needs to use whatever code construct is used for the check in the if-statement above.
+                         */
                         this.module.notificationSystem.addHoverNotification(
                             context?.token,
                             { identifier: newText },
@@ -501,7 +520,7 @@ export class EventHandler {
             }
 
             case EditAction.SelectClosestTokenBelow: {
-				this.module.focus.navigateDown();
+                this.module.focus.navigateDown();
 
                 e.stopPropagation();
                 e.preventDefault();
@@ -580,7 +599,7 @@ export class EventHandler {
                 break;
 
             case EditAction.DisplayGreaterThanSuggestion:
-                if(this.module.isAbleToInsertComparator(context)){
+                if (this.module.isAbleToInsertComparator(context)) {
                     this.module.menuController.buildSingleLevelMenu(
                         [ConstructKeys.GreaterThan, ConstructKeys.GreaterThanOrEqual],
                         Util.getInstance(this.module).constructActions,
@@ -596,7 +615,7 @@ export class EventHandler {
                 break;
 
             case EditAction.DisplayLessThanSuggestion:
-                if(this.module.isAbleToInsertComparator(context)){
+                if (this.module.isAbleToInsertComparator(context)) {
                     this.module.menuController.buildSingleLevelMenu(
                         [ConstructKeys.LessThan, ConstructKeys.LessThanOrEqual],
                         Util.getInstance(this.module).constructActions,
@@ -657,7 +676,7 @@ export class EventHandler {
 
             case EditAction.SelectMenuSuggestionAbove:
                 this.module.menuController.focusOptionAbove();
-                
+
                 e.stopPropagation();
                 e.preventDefault();
                 break;
@@ -704,7 +723,7 @@ export class EventHandler {
     }
 
     onMouseDown(e) {
-		this.module.focus.navigatePos(e.target.position);
+        this.module.focus.navigatePos(e.target.position);
     }
 
     onButtonDown(id: string) {
@@ -726,7 +745,7 @@ export class EventHandler {
                 );
 
                 break;
-                
+
             case "add-randint-btn":
                 this.module.insert(
                     new ast.FunctionCallStmt(
@@ -738,7 +757,7 @@ export class EventHandler {
                         ast.DataType.Number
                     )
                 );
-                
+
                 break;
 
             case "add-range-btn":
@@ -953,7 +972,7 @@ export class EventHandler {
 
             case "add-list-elem-assign-btn":
                 this.module.insert(new ast.ListElementAssignment());
-                
+
                 break;
 
             default:

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -378,6 +378,17 @@ export class Focus {
     //     return false;
     // }
 
+    highlightTextEditableHole(){
+        const context = this.getContext();
+
+        if(
+           (context.token) && 
+           (context.token instanceof ast.IdentifierTkn || context.token instanceof ast.EditableTextTkn)){
+
+            context.token.notify(ast.CallbackType.focus);
+        }
+    }
+
     private getTokenAtStatementColumn(statement: ast.Statement, column: number): ast.CodeConstruct {
         const tokensStack = new Array<ast.CodeConstruct>();
 

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -11,8 +11,8 @@ export class Focus {
         this.module = module;
     }
 
-    getTextEditableItem(): ast.TextEditable {
-        const context = this.getContext();
+    getTextEditableItem(providedContext?: Context): ast.TextEditable {
+        const context = providedContext ? providedContext : this.getContext();
 
         if (context.token instanceof ast.IdentifierTkn || context.token instanceof ast.EditableTextTkn) {
             return context.token;
@@ -265,8 +265,8 @@ export class Focus {
     /**
      * Returns true if the focus is within a text editable token, otherwise, returns false.
      */
-    isTextEditable(): boolean {
-        const context = this.getContext();
+    isTextEditable(providedContext?: Context): boolean {
+        const context = providedContext ? providedContext : this.getContext();
 
         return (
             (context.token != null && context.token.isTextEditable) ||

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -104,11 +104,10 @@ export class Focus {
                 // if clicked on a hole => select the hole
                 this.selectCode(focusedToken);
             } else if (focusedToken instanceof ast.EditableTextTkn || focusedToken instanceof ast.IdentifierTkn) {
-                // if clicked on a text-editable code construct (identifier or a literal) => navigate to the clicked position
+                // if clicked on a text-editable code construct (identifier or a literal) => navigate to the clicked position (or select it if it's empty)
 
-                if (focusedToken.text.length != 0) {
-                    // don't select it
-                }
+                if (focusedToken.text.length != 0) this.module.editor.monaco.setPosition(pos);
+                else this.selectCode(focusedToken);
             } else {
                 const hitDistance = pos.column - focusedToken.left;
                 const tokenLength = focusedToken.right - focusedToken.left + 1;

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -1,0 +1,498 @@
+import * as monaco from 'monaco-editor';
+import * as ast from '../syntax-tree/ast';
+
+export class Focus {
+	module: ast.Module;
+
+	/**
+	 * If the focus is on or within a token, this will have its value, otherwise it will be null.
+	 */
+	focusedToken: ast.CodeConstruct;
+
+	/**
+	 * The statement in which we are focused in
+	 */
+	focusedStatement: ast.Statement;
+
+	// these selections occur using the mouse drag or shift arrow key
+	// multiToken; // array of tokens that the user has selected
+	// multiStatement; // array of statements that the user has selected
+
+	constructor(module: ast.Module) {
+		this.module = module;
+	}
+
+	/**
+	 * This is mostly called from the AST, for example after a code has been inserted and the cursor should focus to
+	 * the first empty hole or after the inserted code.
+	 */
+	update(navFocus: NavigationFocus) {
+		if (navFocus.position == null && navFocus.token != null) {
+			this.focusedToken = navFocus.token;
+			this.focusedStatement = navFocus.token.getParentStatement();
+
+			let selection = new monaco.Selection(
+				navFocus.token.getLineNumber(),
+				navFocus.token.right,
+				navFocus.token.getLineNumber(),
+				navFocus.token.left
+			);
+			this.module.editor.monaco.setSelection(selection);
+		} else if (navFocus.position != null && navFocus.token == null) {
+			this.focusedToken = null;
+			this.focusedStatement = null;
+
+			this.module.editor.monaco.setPosition(navFocus.position);
+		} else if (navFocus.token != null && navFocus.select == false) {
+			this.focusedToken = navFocus.token;
+			this.focusedStatement = navFocus.token.getParentStatement();
+		}
+	}
+
+	private selectFocusedToken() {
+		if (this.focusedToken != null) {
+			let selection = new monaco.Selection(
+				this.focusedToken.getLineNumber(),
+				this.focusedToken.right,
+				this.focusedToken.getLineNumber(),
+				this.focusedToken.left
+			);
+
+			this.module.editor.monaco.setSelection(selection);
+		}
+	}
+
+	navigatePos(pos: monaco.Position): NavigationFocus {
+		let navFocus = new NavigationFocus();
+		navFocus.select = true;
+		this.focusedStatement = this.getStatementAtLineNumber(pos.lineNumber);
+
+		// if what the user has clicked on is a hole => select it
+		// o.w. just set this.focusedToken to null and set the cursor to either the beginning or the end of it (based on its position)
+
+		/**
+		 * selectable items:
+		 * empty holes
+		 * 
+		 */
+
+		/**
+		 * Clicking within literals => should put the cursor right there
+		 */
+
+		// click non-selectable things:
+		// beginning
+		// ending
+
+		// clicked at an empty statement => just update focusedStatement
+		if (this.focusedStatement instanceof ast.EmptyLineStmt) {
+			navFocus.position = new monaco.Position(pos.lineNumber, this.focusedStatement.left);
+			// TODO
+			// TODO: THIS IS TEMPORARY JUST TO UPDATE FOCUSEDNODE IN AST.
+			// TODO
+			navFocus.token = this.focusedStatement;
+
+			this.focusedToken = null;
+			this.module.editor.monaco.setPosition(navFocus.position);
+
+			return navFocus;
+		}
+
+		// clicked before a statement => navigate to the beginning of the statement
+		if (pos.column <= this.focusedStatement.left) {
+			navFocus.position = new monaco.Position(pos.lineNumber, this.focusedStatement.left);
+			this.focusedToken = navFocus.token = null;
+			this.module.editor.monaco.setPosition(navFocus.position);
+
+			return navFocus;
+		}
+
+		// clicked before a statement => navigate to the end of the line
+		if (pos.column >= this.focusedStatement.right) {
+			navFocus.position = new monaco.Position(pos.lineNumber, this.focusedStatement.right);
+			this.focusedToken = navFocus.token = null;
+			this.module.editor.monaco.setPosition(navFocus.position);
+
+			return navFocus;
+		}
+
+		// look into the tokens of the statement:
+		this.focusedToken = this.getTokenAtStatementColumn(this.focusedStatement, pos.column);
+
+		if (this.focusedToken instanceof ast.Token && this.focusedToken.isEmpty) {
+			// if clicked on a hole => select the hole
+			this.selectFocusedToken();
+			navFocus.token = this.focusedToken;
+			navFocus.position = null;
+
+			return navFocus;
+		} else if (this.focusedToken instanceof ast.EditableTextTkn || this.focusedToken instanceof ast.IdentifierTkn) {
+			// if clicked on a text-editable code construct (identifier or a literal) => navigate to the clicked position
+			navFocus.token = this.focusedToken;
+			navFocus.position = null;
+
+			if (this.focusedToken.text.length != 0) navFocus.select = false;
+
+			return navFocus;
+		} else {
+			let hitDistance = pos.column - this.focusedToken.left;
+			let tokenLength = this.focusedToken.right - this.focusedToken.left + 1;
+
+			if (hitDistance < tokenLength / 2) {
+				// go to the beginning (or the empty token before this)
+
+				if (this.focusedToken.left - 1 > this.focusedStatement.left) {
+					let tokenBefore = this.getTokenAtStatementColumn(this.focusedStatement, this.focusedToken.left - 1);
+
+					if (tokenBefore instanceof ast.Token && tokenBefore.isEmpty) {
+						this.focusedToken = tokenBefore;
+
+						this.selectFocusedToken();
+
+						navFocus.token = this.focusedToken;
+						navFocus.position = null;
+
+						return navFocus;
+					} else if (tokenBefore instanceof ast.Token && (tokenBefore instanceof ast.EditableTextTkn || tokenBefore instanceof ast.IdentifierTkn)) {
+						this.focusedToken = navFocus.token = tokenBefore;
+						navFocus.select = false;
+						navFocus.position = null;
+
+						return navFocus;
+					}
+				}
+
+				navFocus.token = null;
+				navFocus.position = new monaco.Position(pos.lineNumber, this.focusedToken.left);
+				this.module.editor.monaco.setPosition(navFocus.position);
+
+				return navFocus;
+			} else {
+				// navigate to the end (or the empty token right after this token)
+
+				let tokenAfter = this.getTokenAtStatementColumn(this.focusedStatement, this.focusedToken.right + 1);
+
+				if (tokenAfter instanceof ast.Token && tokenAfter.isEmpty) {
+					this.focusedToken = tokenAfter;
+
+					this.selectFocusedToken();
+
+					navFocus.token = this.focusedToken;
+					navFocus.position = null;
+
+					return navFocus;
+				} else {
+					navFocus.token = null;
+					navFocus.position = new monaco.Position(pos.lineNumber, this.focusedToken.right);
+					this.module.editor.monaco.setPosition(navFocus.position);
+
+					return navFocus;
+				}
+			}
+		}
+	}
+
+	navigateUp() : NavigationFocus {
+		let curPosition = this.module.editor.monaco.getPosition();
+
+		if (curPosition.lineNumber > 1)
+			return this.navigatePos(new monaco.Position(curPosition.lineNumber - 1, curPosition.column));
+		else return this.navigatePos(new monaco.Position(curPosition.lineNumber, 1));
+	}
+
+	navigateDown()  : NavigationFocus{
+		let navFocus = new NavigationFocus();
+
+		// could try doing navigatePos(down) 
+		// if null => just go to the end of the line
+
+		return navFocus;
+	}
+
+	navigateRight()  : NavigationFocus{
+		let navFocus = new NavigationFocus();
+		navFocus.token = this.focusedToken;
+
+		if (this.onEndOfLine()) {
+			// same code as navigateDown (just to the beginning of down)
+			console.log("+ 1 is down")
+		} else {
+			let curSelection = this.module.editor.monaco.getSelection();
+			let curPos = this.module.editor.monaco.getPosition();
+			let nextColumn = curPos.column;
+
+			if (curSelection.endColumn != curSelection.startColumn)
+				nextColumn = curSelection.endColumn;
+
+			let tokenAfter = this.getTokenAtStatementColumn(this.focusedStatement, nextColumn);
+
+			if (tokenAfter instanceof ast.NonEditableTkn) {
+				// should skip this NonEditableTkn, and move to the next thing after it.
+
+				let tokenAfterAfter = this.getTokenAtStatementColumn(this.focusedStatement, tokenAfter.right);
+
+				if (tokenAfterAfter instanceof ast.Token && tokenAfterAfter.isEmpty) {
+					this.focusedToken = tokenAfterAfter;
+
+					this.selectFocusedToken();
+
+					navFocus.token = this.focusedToken;
+					navFocus.position = null;
+
+					return navFocus;
+				} else if (tokenAfterAfter instanceof ast.EditableTextTkn || tokenAfterAfter instanceof ast.IdentifierTkn) {
+					navFocus.position = new monaco.Position(curPos.lineNumber, tokenAfterAfter.left);
+					this.module.editor.monaco.setPosition(navFocus.position);
+
+					this.focusedToken = navFocus.token = tokenAfterAfter;
+					navFocus.select = false;
+
+					return navFocus;
+				} else if (tokenAfterAfter != null){
+					// probably its another expression, but should go to the beginning of it
+					navFocus.position = new monaco.Position(curPos.lineNumber, tokenAfterAfter.left);
+					this.module.editor.monaco.setPosition(navFocus.position);
+
+					this.focusedToken = navFocus.token = null;
+
+					return navFocus;
+				}else {
+					navFocus.position = new monaco.Position(curPos.lineNumber, tokenAfter.right);
+					this.module.editor.monaco.setPosition(navFocus.position);
+
+					this.focusedToken = navFocus.token = null;
+
+					return navFocus;
+
+				}
+
+
+			} else if (tokenAfter instanceof ast.Token && tokenAfter.isEmpty) {
+				// if char[col + 1] is H => just select H
+				console.log("+1 is H")
+
+				navFocus.token = tokenAfter;
+				navFocus.position = null;
+
+				this.selectFocusedToken();
+
+			} else if (tokenAfter instanceof ast.EditableTextTkn || tokenAfter instanceof ast.IdentifierTkn) {
+				// if char[col + 1] is a literal => go through it
+				console.log("+1 is L")
+
+				navFocus.position = new monaco.Position(curPos.lineNumber, tokenAfter.left);
+				this.module.editor.monaco.setPosition(navFocus.position);
+
+				this.focusedToken = navFocus.token = tokenAfter;
+				navFocus.select = false;
+			}
+		}
+
+		return navFocus;
+	}
+
+	navigateLeft() : NavigationFocus {
+		let navFocus = new NavigationFocus();
+		navFocus.token = this.focusedToken;
+
+		if (this.onBeginningOfLine()) {
+			// same code as navigateUp (just to the end of up)
+			console.log("- 1 is up")
+		} else {
+			let curSelection = this.module.editor.monaco.getSelection();
+			let curPos = this.module.editor.monaco.getPosition();
+			let prevColumn = this.module.editor.monaco.getPosition().column - 1;
+
+			if (curSelection.endColumn != curSelection.startColumn)
+				prevColumn = curSelection.startColumn - 1
+
+			let tokenBefore = this.getTokenAtStatementColumn(this.focusedStatement, prevColumn);
+
+			if (tokenBefore instanceof ast.NonEditableTkn) {
+				// if char[col - 1] is N => just go to the beginning of N
+				console.log("-1 is N")
+
+				let tokenBeforeBefore = this.getTokenAtStatementColumn(this.focusedStatement, tokenBefore.left - 1);
+
+				if (tokenBeforeBefore instanceof ast.Token && tokenBeforeBefore.isEmpty) {
+					this.focusedToken = tokenBeforeBefore;
+
+					this.selectFocusedToken();
+
+					navFocus.token = this.focusedToken;
+					navFocus.position = null;
+
+					return navFocus;
+				} else if (tokenBeforeBefore instanceof ast.Token && (tokenBeforeBefore instanceof ast.EditableTextTkn || tokenBeforeBefore instanceof ast.IdentifierTkn)) {
+					navFocus.position = new monaco.Position(curPos.lineNumber, tokenBeforeBefore.right);
+					this.module.editor.monaco.setPosition(navFocus.position);
+
+					this.focusedToken = navFocus.token = tokenBeforeBefore;
+					navFocus.select = false;
+
+					return navFocus;
+				} else {
+					this.focusedToken = navFocus.token = null;
+					navFocus.position = new monaco.Position(curPos.lineNumber, tokenBefore.left);
+					this.module.editor.monaco.setPosition(navFocus.position);
+	
+					return navFocus;
+				}
+
+
+			} else if (tokenBefore instanceof ast.Token && tokenBefore.isEmpty) {
+				// if char[col - 1] is H => just select H
+				console.log("-1 is H")
+
+				navFocus.token = tokenBefore;
+				navFocus.position = null;
+
+				this.selectFocusedToken();
+
+			} else if (tokenBefore instanceof ast.EditableTextTkn) {
+				// if char[col - 1] is a literal => go through it
+				console.log("-1 is L")
+			}
+		}
+
+		return navFocus;
+	}
+
+	/**
+	 * Returns true if the focus is within a text editable token, otherwise, returns false.
+	 */
+	isTextEditable(): boolean {
+		return this.focusedToken != null && this.focusedToken.isTextEditable;
+	}
+
+	/**
+	 * Returns true if the focus is on an empty line, otherwise, returns false.
+	 */
+	onEmptyLine(): boolean {
+		let curSelection = this.module.editor.monaco.getSelection();
+
+		if (curSelection.startColumn == curSelection.endColumn) {
+			let curPosition = curSelection.getStartPosition();
+
+			return this.isEmptyLine(this.module.editor.monaco.getModel().getLineContent(curPosition.lineNumber));
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns true if the focus is on the end of a line, otherwise, returns false.
+	 */
+	onEndOfLine(): boolean {
+		let curSelection = this.module.editor.monaco.getSelection();
+
+		if (curSelection.startColumn == curSelection.endColumn) {
+			let curPosition = curSelection.getStartPosition();
+
+			if (this.focusedStatement != null && curPosition.column == this.focusedStatement.right + 1) return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns true if the focus is on the beginning of a line, otherwise, returns false.
+	 */
+	onBeginningOfLine(): boolean {
+		let curSelection = this.module.editor.monaco.getSelection();
+
+		// if (curSelection.startColumn == curSelection.endColumn) {
+		// 	let curPosition = curSelection.getStartPosition();
+
+		//     if (curPosition.column == 1) return true;
+
+		// 	let lineContent = this.module.editor.monaco.getModel().getLineContent(curPosition.lineNumber);
+
+		//     if (curPosition.column - 1 == ) return true;
+		// }
+
+		return false;
+	}
+
+	/**
+	 * Returns true if a line exists above the focused line, otherwise, returns false.
+	 */
+	existsLineAbove(): boolean {
+		// let curPos = this.module.editor.monaco.getPosition();
+		// let lineStmt = this.getStmtFromLine(curPos.lineNumber);
+
+		// if (lineStmt != null) {
+
+		// }
+
+		return false;
+	}
+
+	/**
+	 * Returns true if a line exists below the focused line, otherwise, returns false.
+	 */
+	existsLineBelow(): boolean {
+		return false;
+	}
+
+	private getTokenAtStatementColumn(statement: ast.Statement, column: number): ast.CodeConstruct {
+		let tokensStack = new Array<ast.CodeConstruct>();
+
+		for (let token of statement.tokens) tokensStack.unshift(token);
+
+		while (tokensStack.length > 0) {
+			let curToken = tokensStack.pop();
+
+			if (column >= curToken.left && column < curToken.right && curToken instanceof ast.Token) return curToken;
+
+			if (curToken instanceof ast.Expression)
+				if (curToken.tokens.length > 0) for (let token of curToken.tokens) tokensStack.unshift(token);
+				else return curToken;
+		}
+
+		return null;
+	}
+
+	private getStatementAtLineNumber(line: number): ast.Statement {
+		let bodyStack = new Array<ast.Statement>();
+
+		for (let stmt of this.module.body) bodyStack.push(stmt);
+
+		while (bodyStack.length > 0) {
+			let curStmt = bodyStack.pop();
+
+			if (line == curStmt.lineNumber) return curStmt;
+			else if (curStmt.hasBody()) {
+				for (let stmt of curStmt.body) bodyStack.push(stmt);
+			}
+		}
+
+		return null;
+	}
+
+	private isEmptyLine(line: string): boolean {
+		return line.trim().length == 0;
+	}
+}
+
+export class NavigationFocus {
+	token?: ast.CodeConstruct = null;
+	position?: monaco.Position = null;
+	select?: boolean = false;
+
+	setPosition(position: monaco.Position) {
+		this.token = null;
+		this.position = position;
+	}
+
+	setToken(token: ast.CodeConstruct) {
+		this.token = token;
+		this.position = null;
+	}
+
+	/**
+	 * token could be null in many circumstances:
+	 * - 
+	 */
+	//
+}

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -169,18 +169,25 @@ export class Focus {
     }
 
     navigateRight() {
+        const curPos = this.module.editor.monaco.getPosition();
+
         if (this.onEndOfLine()) {
-            // same code as navigateDown (just to the beginning of down)
-            console.log("+ 1 is down");
+            const lineBelow = this.getStatementAtLineNumber(curPos.lineNumber + 1);
+
+            if (lineBelow != null) {
+                this.module.editor.monaco.setPosition(new monaco.Position(lineBelow.lineNumber, lineBelow.left));
+            }
         } else {
             const curSelection = this.module.editor.monaco.getSelection();
-            const curPos = this.module.editor.monaco.getPosition();
             const focusedLineStatement = this.getStatementAtLineNumber(curPos.lineNumber);
             let nextColumn = curPos.column;
 
             if (curSelection.endColumn != curSelection.startColumn) nextColumn = curSelection.endColumn;
 
-            if (curSelection.startColumn != curSelection.endColumn && curSelection.endColumn == focusedLineStatement.right) {
+            if (
+                curSelection.startColumn != curSelection.endColumn &&
+                curSelection.endColumn == focusedLineStatement.right
+            ) {
                 // if selected a thing that is at the beginning of a line (usually an identifier) => nav to the beginning of the line
                 this.module.editor.monaco.setPosition(
                     new monaco.Position(curPos.lineNumber, focusedLineStatement.right)
@@ -230,12 +237,18 @@ export class Focus {
     }
 
     navigateLeft() {
+        const curPos = this.module.editor.monaco.getPosition();
+
         if (this.onBeginningOfLine()) {
-            // same code as navigateUp (just to the end of up)
-            console.log("- 1 is up");
+            if (curPos.lineNumber > 1) {
+                const lineBelow = this.getStatementAtLineNumber(curPos.lineNumber - 1);
+
+                if (lineBelow != null) {
+                    this.module.editor.monaco.setPosition(new monaco.Position(lineBelow.lineNumber, lineBelow.right));
+                }
+            } else return;
         } else {
             const curSelection = this.module.editor.monaco.getSelection();
-            const curPos = this.module.editor.monaco.getPosition();
             const focusedLineStatement = this.getStatementAtLineNumber(curPos.lineNumber);
             let prevColumn = this.module.editor.monaco.getPosition().column - 1;
 
@@ -308,7 +321,7 @@ export class Focus {
             const curPosition = curSelection.getStartPosition();
             const focusedLineStatement = this.getStatementAtLineNumber(curPosition.lineNumber);
 
-            if (focusedLineStatement != null && curPosition.column == focusedLineStatement.right + 1) return true;
+            if (focusedLineStatement != null && curPosition.column == focusedLineStatement.right) return true;
         }
 
         return false;

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -5,10 +5,20 @@ export class Focus {
     module: ast.Module;
 
     // TODO: NYI
-    callbacks = new Array<(Context) => {}>();
+    onNavChangeCallbacks = new Array<(c: Context) => void>();
 
     constructor(module: ast.Module) {
         this.module = module;
+    }
+
+    subscribeCallback(callback: (c: Context) => void){
+        this.onNavChangeCallbacks.push(callback);
+    }
+
+    private onChange(){
+        this.onNavChangeCallbacks.forEach(callback => {
+            callback(this.getContext());
+        })
     }
 
     getTextEditableItem(providedContext?: Context): ast.TextEditable {
@@ -29,7 +39,6 @@ export class Focus {
         }
     }
 
-    subscribeCallback() {}
 
     // TODO: when changing context (through navigation) and updating focusedToken => make sure to call .notify
 
@@ -66,6 +75,8 @@ export class Focus {
         } else if (newContext.positionToMove != undefined) {
             this.module.editor.monaco.setPosition(newContext.positionToMove);
         }
+
+        this.onChange();
     }
 
     navigatePos(pos: monaco.Position) {
@@ -74,76 +85,64 @@ export class Focus {
         // clicked at an empty statement => just update focusedStatement
         if (focusedLineStatement instanceof ast.EmptyLineStmt) {
             this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedLineStatement.left));
-
-            return;
         }
 
         // clicked before a statement => navigate to the beginning of the statement
-        if (pos.column <= focusedLineStatement.left) {
+        else if (pos.column <= focusedLineStatement.left) {
             this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedLineStatement.left));
-
-            return;
         }
 
         // clicked before a statement => navigate to the end of the line
-        if (pos.column >= focusedLineStatement.right) {
+        else if (pos.column >= focusedLineStatement.right) {
             this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedLineStatement.right));
-
-            return;
         }
+        else{
+            // look into the tokens of the statement:
+            const focusedToken = this.getTokenAtStatementColumn(focusedLineStatement, pos.column);
 
-        // look into the tokens of the statement:
-        const focusedToken = this.getTokenAtStatementColumn(focusedLineStatement, pos.column);
+            if (focusedToken instanceof ast.Token && focusedToken.isEmpty) {
+                // if clicked on a hole => select the hole
+                this.selectCode(focusedToken);
 
-        if (focusedToken instanceof ast.Token && focusedToken.isEmpty) {
-            // if clicked on a hole => select the hole
-            this.selectCode(focusedToken);
+            } else if (focusedToken instanceof ast.EditableTextTkn || focusedToken instanceof ast.IdentifierTkn) {
+                // if clicked on a text-editable code construct (identifier or a literal) => navigate to the clicked position
 
-            return;
-        } else if (focusedToken instanceof ast.EditableTextTkn || focusedToken instanceof ast.IdentifierTkn) {
-            // if clicked on a text-editable code construct (identifier or a literal) => navigate to the clicked position
+                if (focusedToken.text.length != 0) {
+                    // don't select it
+                }
 
-            if (focusedToken.text.length != 0) {
-                // don't select it
-            }
+            } else {
+                const hitDistance = pos.column - focusedToken.left;
+                const tokenLength = focusedToken.right - focusedToken.left + 1;
 
-            return;
-        } else {
-            const hitDistance = pos.column - focusedToken.left;
-            const tokenLength = focusedToken.right - focusedToken.left + 1;
+                if (hitDistance < tokenLength / 2) {
+                    // go to the beginning (or the empty token before this)
 
-            if (hitDistance < tokenLength / 2) {
-                // go to the beginning (or the empty token before this)
+                    if (focusedToken.left - 1 > focusedLineStatement.left) {
+                        const tokenBefore = this.getTokenAtStatementColumn(focusedLineStatement, focusedToken.left - 1);
 
-                if (focusedToken.left - 1 > focusedLineStatement.left) {
-                    const tokenBefore = this.getTokenAtStatementColumn(focusedLineStatement, focusedToken.left - 1);
+                        if (tokenBefore instanceof ast.Token && tokenBefore.isEmpty) {
+                            this.selectCode(tokenBefore);
+                        }
+                    }
 
-                    if (tokenBefore instanceof ast.Token && tokenBefore.isEmpty) {
-                        this.selectCode(tokenBefore);
+                    this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedToken.left));
 
-                        return;
+                } else {
+
+                    // navigate to the end (or the empty token right after this token)
+                    const tokenAfter = this.getTokenAtStatementColumn(focusedLineStatement, focusedToken.right + 1);
+
+                    if (tokenAfter instanceof ast.Token && tokenAfter.isEmpty) {
+                        this.selectCode(tokenAfter);
+                    } else {
+                        this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedToken.right));
                     }
                 }
-
-                this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedToken.left));
-
-                return;
-            } else {
-                // navigate to the end (or the empty token right after this token)
-
-                const tokenAfter = this.getTokenAtStatementColumn(focusedLineStatement, focusedToken.right + 1);
-
-                if (tokenAfter instanceof ast.Token && tokenAfter.isEmpty) {
-                    this.selectCode(tokenAfter);
-
-                    return;
-                } else {
-                    this.module.editor.monaco.setPosition(new monaco.Position(pos.lineNumber, focusedToken.right));
-
-                    return;
-                }
             }
         }
+
+        this.onChange();
     }
 
     navigateUp() {
@@ -206,23 +205,19 @@ export class Focus {
                 if (tokenAfterAfter instanceof ast.Token && tokenAfterAfter.isEmpty) {
                     this.selectCode(tokenAfterAfter);
 
-                    return;
                 } else if (
                     tokenAfterAfter instanceof ast.EditableTextTkn ||
                     tokenAfterAfter instanceof ast.IdentifierTkn
                 ) {
                     this.module.editor.monaco.setPosition(new monaco.Position(curPos.lineNumber, tokenAfterAfter.left));
 
-                    return;
                 } else if (tokenAfterAfter != null) {
                     // probably its another expression, but should go to the beginning of it
                     this.module.editor.monaco.setPosition(new monaco.Position(curPos.lineNumber, tokenAfterAfter.left));
 
-                    return;
                 } else {
                     this.module.editor.monaco.setPosition(new monaco.Position(curPos.lineNumber, tokenAfter.right));
 
-                    return;
                 }
             } else if (tokenAfter instanceof ast.Token && tokenAfter.isEmpty) {
                 // if char[col + 1] is H => just select H
@@ -234,6 +229,8 @@ export class Focus {
                 this.module.editor.monaco.setPosition(new monaco.Position(curPos.lineNumber, tokenAfter.left));
             }
         }
+
+        this.onChange();
     }
 
     navigateLeft() {
@@ -273,7 +270,6 @@ export class Focus {
                 if (tokenBeforeBefore instanceof ast.Token && tokenBeforeBefore.isEmpty) {
                     this.selectCode(tokenBeforeBefore);
 
-                    return;
                 } else if (
                     tokenBeforeBefore instanceof ast.Token &&
                     (tokenBeforeBefore instanceof ast.EditableTextTkn || tokenBeforeBefore instanceof ast.IdentifierTkn)
@@ -282,11 +278,9 @@ export class Focus {
                         new monaco.Position(curPos.lineNumber, tokenBeforeBefore.right)
                     );
 
-                    return;
                 } else {
                     this.module.editor.monaco.setPosition(new monaco.Position(curPos.lineNumber, tokenBefore.left));
 
-                    return;
                 }
             } else if (tokenBefore instanceof ast.Token && tokenBefore.isEmpty) {
                 // if char[col - 1] is H => just select H
@@ -296,6 +290,8 @@ export class Focus {
                 // if char[col - 1] is a literal => go through it
             }
         }
+
+        this.onChange();
     }
 
     /**
@@ -368,17 +364,6 @@ export class Focus {
         const curLine = this.getFocusedStatement();
 
         return curLine instanceof ast.EmptyLineStmt;
-    }
-
-    highlightTextEditableHole() {
-        const context = this.getContext();
-
-        if (
-            context.token &&
-            (context.token instanceof ast.IdentifierTkn || context.token instanceof ast.EditableTextTkn)
-        ) {
-            context.token.notify(ast.CallbackType.focus);
-        }
     }
 
     /**

--- a/src/editor/hole.ts
+++ b/src/editor/hole.ts
@@ -141,4 +141,10 @@ export class Hole {
         this.element.remove();
         this.removed = true;
     }
+
+    static disableEditableHoleHighlights(){
+        Hole.holes.forEach(hole => {
+            hole.element.classList.remove(Hole.editableHoleClass)
+        })
+    }
 }

--- a/src/editor/hole.ts
+++ b/src/editor/hole.ts
@@ -9,6 +9,7 @@ import {
     DataType,
 } from "../syntax-tree/ast";
 import { Editor } from "./editor";
+import { Context } from "./focus";
 
 export class Hole {
     static editableHoleClass = "editableHole";
@@ -142,9 +143,21 @@ export class Hole {
         this.removed = true;
     }
 
-    static disableEditableHoleHighlights(){
+    static disableEditableHoleOutlines(){
         Hole.holes.forEach(hole => {
             hole.element.classList.remove(Hole.editableHoleClass)
         })
+    }
+
+    static outlineTextEditableHole(context: Context){
+        if(context.token && (context.token instanceof IdentifierTkn || context.token instanceof EditableTextTkn)){
+            context.token.notify(CallbackType.focus);
+        }
+        else if(context.tokenToRight && (context.tokenToRight instanceof IdentifierTkn || context.tokenToRight instanceof EditableTextTkn)){
+            context.tokenToRight.notify(CallbackType.focus);
+        }
+        else if(context.tokenToLeft && (context.tokenToLeft instanceof IdentifierTkn || context.tokenToLeft instanceof EditableTextTkn)){
+            context.tokenToLeft.notify(CallbackType.focus);
+        }
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,11 +9,6 @@
         <div id="editor-container">
             <div id="editor-toolbox">
                 <div class="group">
-                    <p>Test</p>
-                    <div id="add-test-array" class="button">arr = [1, 2, 3, 4, 5])</div>
-                </div>
-
-                <div class="group">
                     <p>Function calls</p>
                     <div id="add-print-btn" class="button">print(<hole></hole>)</div>
                     <div id="add-randint-btn" class="button">randint(<hole></hole>, <hole></hole>)</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import "./css/index.css";
-import * as AST from "./syntax-tree/ast";
+import * as ast from "./syntax-tree/ast";
 
 // @ts-ignore
 self.MonacoEnvironment = {
@@ -20,4 +20,4 @@ self.MonacoEnvironment = {
     },
 };
 
-export const nova = new AST.Module("editor");
+export const nova = new ast.Module("editor");

--- a/src/notification-system/notification-system-controller.ts
+++ b/src/notification-system/notification-system-controller.ts
@@ -118,11 +118,21 @@ export class NotificationSystemController {
 
     /**
      * Add a pop-up notification to the editor at the specified position.
+     * 
+     * If args and errMsgType are specified, there is no need to specify text as it will be auto-generated.
      */
-    addPopUpNotification() {
-        this.notifications.push(
-            new PopUpNotification(this.editor, this.notifications.length, "Pop Up!", { left: 0, top: 0 })
-        );
+    addPopUpNotification(args: any, pos: object = {left: 0, top: 0}, errMsgType?: ErrorMessage, text?: string) {
+        if(text){
+            this.notifications.push(
+                new PopUpNotification(this.editor, this.notifications.length, text, pos)
+            );
+        }
+        else{
+            this.notifications.push(
+                new PopUpNotification(this.editor, this.notifications.length, this.msgGenerator.generateMsg(errMsgType, args), pos)
+            );
+        }
+
         const notif = this.notifications[this.notifications.length - 1];
 
         setTimeout(() => {

--- a/src/notification-system/notification-system-controller.ts
+++ b/src/notification-system/notification-system-controller.ts
@@ -147,6 +147,9 @@ export class NotificationSystemController {
             this.notifications.splice(code.notification.index, 1);
             code.notification = null;
         }
+        else{
+            console.warn("Could not remove notification from construct: " + code)
+        }
     }
 
     clearAllNotifications() {

--- a/src/suggestions/suggestions-controller.ts
+++ b/src/suggestions/suggestions-controller.ts
@@ -6,7 +6,7 @@ import { ConstructDoc } from "./construct-doc";
 /*
  *A tree menu that can hold options for the user and link through those options to other menus.
  */
-export class Menu {
+class Menu {
     //Menu object
     private isMenuOpen: boolean = false;
     options: MenuOption[] = [];
@@ -116,7 +116,7 @@ export class Menu {
     }
 
     //An empty option is one that does not link to another menu and also does not have a select action
-    countEmptyOptions() {
+    private countEmptyOptions() {
         let count = 0;
         
         this.options.forEach((option) => {
@@ -219,7 +219,7 @@ export class Menu {
 /**
  * An option within a menu that can link to another menu or perform an action when selected.
  */
-export class MenuOption {
+class MenuOption {
     //menu this option links to
     private childMenu: Menu;
     //menu this option is a part of
@@ -268,7 +268,7 @@ export class MenuOption {
         });
     }
 
-    addArrowImg() {
+    private addArrowImg() {
         if (this.childMenu) {
             const image = document.createElement("img");
             image.src = "./src/res/img/optionArrow.png";
@@ -630,8 +630,10 @@ export class MenuController {
                 "Top",
             ];
 
+            const context = this.module.focus.getContext();
+
             //add variable references
-            const refs = this.module.getValidVariableReferences(this.module.focusedNode);
+            const refs = this.module.getValidVariableReferences(context.token);
             const identifiers = refs.map((ref) => (ref.statement as VarAssignmentStmt).getIdentifier());
             refs.forEach((ref) => {
                 if (ref.statement instanceof VarAssignmentStmt) {
@@ -697,7 +699,7 @@ export class MenuController {
      *                  Provide an empty map if no custom actions are necessary.
      * @param pos       Initial top-left corner of the menu.
      */
-    buildMenuFromOptionMap(
+    private buildMenuFromOptionMap(
         map: Map<string, Array<string | ConstructKeys>>,
         keys: Array<string>,
         rootKey: string,
@@ -754,7 +756,7 @@ export class MenuController {
      *
      * @param pos        Initial top-left corner of the menu.
      */
-    buildMenuFromLinkageMap(
+    private buildMenuFromLinkageMap(
         menus: Array<ConstructKeys | string>[],
         linkageMap: Map<string, number[]>,
         actionMap: Map<string, Function>,
@@ -843,7 +845,7 @@ export class MenuController {
         return null;
     }
 
-    openRootMenu() {
+    private openRootMenu() {
         if (this.menus.length && this.indexOfRootMenu >= 0) {
             if (!this.menus[this.indexOfRootMenu].isOpen()) {
                 this.menus[this.indexOfRootMenu].open();

--- a/src/suggestions/suggestions-controller.ts
+++ b/src/suggestions/suggestions-controller.ts
@@ -633,7 +633,8 @@ export class MenuController {
             const context = this.module.focus.getContext();
 
             //add variable references
-            const refs = this.module.getValidVariableReferences(context.token);
+            const focusedNode = context.token && context.selected ? context.token : context.lineStatement;
+            const refs = this.module.getValidVariableReferences(focusedNode);
             const identifiers = refs.map((ref) => (ref.statement as VarAssignmentStmt).getIdentifier());
             refs.forEach((ref) => {
                 if (ref.statement instanceof VarAssignmentStmt) {

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -10,6 +10,7 @@ import { ConstructCompleter } from "../typing-system/construct-completer";
 import { MenuController } from "../suggestions/suggestions-controller";
 import { ConstructKeys, Util } from "../utilities/util";
 import { Focus, Context, UpdatableContext } from "../editor/focus";
+import { Hole } from "../editor/hole";
 
 export class Callback {
     static counter: number;
@@ -2256,9 +2257,14 @@ export class Module {
         }
     }
 
+///------------------VALIDATOR BEGIN
+
+
     //TODO: How we insert also depends on where we are in relation to the construct: to the left, to the right or within.
     // > 123 ==> --- > 123      and      123 > ==> 123 > ---      and    --- ==> --- > ---
     //I don't know if we want this function to return this type of information.
+
+    //TODO: This method will not be part of module in the future, that is why it needs a context param
 
     //Accepts context because this will not be part of Module in the future
     isAbleToInsertComparator(context: Context, insertEquals: boolean = false): boolean {
@@ -2461,6 +2467,10 @@ export class Module {
             }
         } else return false;
     }
+
+
+///------------------VALIDATOR END
+
 
     insert(code: CodeConstruct, insertInto?: CodeConstruct) {
         //TODO: Probably want an overload of insert to take care of this case

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -492,12 +492,11 @@ export abstract class Statement implements CodeConstruct {
     replace(code: CodeConstruct, index: number) {
         // Notify the token being replaced
         const toReplace = this.tokens[index];
-        if (toReplace instanceof Statement || toReplace instanceof Expression || toReplace instanceof Token) {
+        if (toReplace) {
             toReplace.notify(CallbackType.delete);
 
-            //any hole-containing tokens need to be notified so their holes are removed
-            if (toReplace instanceof Statement || toReplace instanceof Expression) {
-                toReplace.tokens.forEach((token) => {
+            if (!(toReplace instanceof Token)) {
+                (toReplace as Statement).tokens.forEach((token) => {
                     if (token instanceof Token) {
                         token.notify(CallbackType.delete);
                     }
@@ -516,6 +515,8 @@ export abstract class Statement implements CodeConstruct {
         else rebuildColumn = (this.tokens[index] as Expression).left;
 
         // replace
+        //TODO: Update focus here? It is good up until now. But once the new construct is inserted, it is not being focused.
+        //The focus goes to the end of line
         this.tokens[index] = code;
 
         if (rebuildColumn) this.rebuild(new monaco.Position(this.lineNumber, rebuildColumn), index);
@@ -2462,6 +2463,7 @@ export class Module {
     }
 
     insert(code: CodeConstruct, insertInto?: CodeConstruct) {
+        console.log(this)
         //TODO: Probably want an overload of insert to take care of this case
         let focusedNodeProvided = false;
         let focusedNode = null;

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -397,7 +397,7 @@ export abstract class Statement implements CodeConstruct {
             }
         }
 
-        const newRight = curPos.column - 1;
+        const newRight = curPos.column;
 
         if (propagateToRoot && this.right != newRight) {
             this.right = newRight;

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -2421,9 +2421,9 @@ export class Module {
                 const statement = insert as Statement;
 
                 if (parentRoot instanceof Statement && parentRoot.hasBody()) {
-                    if (insert instanceof ElseStatement && parentRoot instanceof IfStatement)
+                    if (insert instanceof ElseStatement && parentRoot instanceof IfStatement){
                         if (parentRoot.isValidElseInsertion(insertInto.indexInRoot, insert)) return true;
-                        else if (!(statement instanceof ElseStatement)) return true;
+                    } else if (!(statement instanceof ElseStatement)) return true;
                 } else if (!(statement instanceof ElseStatement)) return true;
             } else if (insertInto.receives.indexOf(AddableType.Expression) > -1) {
                 let isValid = true;

--- a/src/typing-system/construct-completer.ts
+++ b/src/typing-system/construct-completer.ts
@@ -6,6 +6,7 @@ import {
     LiteralValExpr,
     Module,
     DataType,
+    Token,
 } from "../syntax-tree/ast";
 import * as monaco from "monaco-editor";
 
@@ -38,11 +39,13 @@ export class ConstructCompleter {
     }
 
     completeArithmeticConstruct(operator: BinaryOperator) {
+        console.log("Refactor me.")
+       /* const context = this.module.focus.getContext();
         //TODO: Currently locate() returns EndOfLine and StartOfLine tokens as well
         //Once that changes, need to modify this to not use the rootNode because presumably it would be returning a statement or an expression
 
         const cursorPos = this.editor.monaco.getPosition();
-        const closestConstruct = this.module.focusedNode.locate(cursorPos).rootNode as CodeConstruct;
+        const closestConstruct = (context.tokenToRight ? context.tokenToRight : context.expressionToRight);
         const parentRoot = closestConstruct.rootNode as CodeConstruct;
 
         if (!(closestConstruct instanceof Module)) {
@@ -83,8 +86,10 @@ export class ConstructCompleter {
                 );
 
                 this.editor.executeEdits(range, newConstruct);
-                this.editor.focusSelection(newLiteralValExpr.getSelection());
+                this.editor.module.focus.updateContext({tokenToSelect: newConstruct.tokens[newConstruct.getRightOperandIndex()] as Token});
+                this.editor.focusSelection();
             }
-        }
+        }*/
     }
 }
+

--- a/src/typing-system/construct-completer.ts
+++ b/src/typing-system/construct-completer.ts
@@ -30,8 +30,8 @@ export class ConstructCompleter {
         this.module = module;
     }
 
-    completeLiteralConstruct(literalType: DataType) {
-        this.module.insert(new LiteralValExpr(literalType));
+    completeLiteralConstruct(literalType: DataType, value: string) {
+        this.module.insert(new LiteralValExpr(literalType, value));
     }
 
     completeBoolLiteralConstruct(boolValue: Number) {


### PR DESCRIPTION
- remove `focusedNode` (and all dependencies to it)
- navigation moves (left/right/up/down as well as clicks and updates after code modifications) will be done through the focus.ts module. This module will be the only module responsible for updating the editor's cursor position and selection. No other module should do these two actions to help with debugging and maintain a clean code.
- the focus.ts contains helper functions such as `getContext()` that would retrieve the full context based on the current selection/focused-position in the editor. the Context will additionally have information about its surrounds to better help with validation.
- the new focus.ts will help us develop a validator.ts module in the future