### PR TITLE
Rework loop variables in for-loops

### DIFF
--- a/src/editor/hole.ts
+++ b/src/editor/hole.ts
@@ -7,6 +7,7 @@ import {
     TypedEmptyExpr,
     VarAssignmentStmt,
     DataType,
+    ForStatement,
 } from "../syntax-tree/ast";
 import { Editor } from "./editor";
 import { Context } from "./focus";
@@ -40,6 +41,12 @@ export class Hole {
 
         if (code instanceof EditableTextTkn || code instanceof IdentifierTkn) {
             this.element.classList.add(Hole.editableHoleClass);
+
+            if(code instanceof IdentifierTkn && code.getParentStatement() instanceof ForStatement){
+                code.subscribe(CallbackType.change, new Callback(() => {
+                    (code.getParentStatement() as ForStatement).loopVar.setIdentifier(code.getRenderText());
+                })
+            )}
 
             code.subscribe(
                 CallbackType.loseFocus,

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -1088,14 +1088,14 @@ export class ForStatement extends Statement {
     private counterIndex: number;
     private rangeIndex: number;
 
+    loopVar: VarAssignmentStmt = null;
+
     //TODO: Statements should not have a data type?
     dataType = DataType.Any;
 
     constructor(root?: CodeConstruct | Module, indexInRoot?: number) {
         super();
 
-        this.buttonId = "add-var-ref-" + VarAssignmentStmt.uniqueId;
-        VarAssignmentStmt.uniqueId++;
 
         this.validEdits.push(EditFunctions.RemoveStatement);
 
@@ -1276,6 +1276,10 @@ export class VarAssignmentStmt extends Statement {
 
     updateButton() {
         document.getElementById(this.buttonId).innerHTML = this.getIdentifier();
+    }
+
+    setIdentifier(identifier: string){
+       (this.tokens[this.identifierIndex] as IdentifierTkn).setIdentifierText(identifier);
     }
 }
 
@@ -1932,7 +1936,7 @@ export class IdentifierTkn extends Token implements TextEditable {
 
     setEditedText(text: string): boolean {
         if (this.validatorRegex.test(text)) {
-            this.text = text;
+            this.setIdentifierText(text);
             (this.rootNode as Statement).rebuild(this.getLeftPosition(), this.indexInRoot);
 
             if (this.text.length > 0) this.isEmpty = false;
@@ -1943,6 +1947,10 @@ export class IdentifierTkn extends Token implements TextEditable {
             this.notify(CallbackType.fail);
             return false;
         }
+    }
+
+    setIdentifierText(text: string){
+        this.text = text;
     }
 }
 
@@ -2170,8 +2178,13 @@ export class Module {
         }
 
         if (newStmt instanceof ForStatement) {
+            const varAssignStmt = new VarAssignmentStmt("", newStmt);
+            varAssignStmt.lineNumber = lineNumber;
+
+            newStmt.loopVar = varAssignStmt;
+
             this.addLoopVariableButtonToToolbox(newStmt);
-            newStmt.scope.references.push(new Reference(newStmt, this.scope));
+            newStmt.scope.references.push(new Reference(varAssignStmt, this.scope));
         }
     }
 
@@ -2264,8 +2277,13 @@ export class Module {
         }
 
         if (newStmt instanceof ForStatement) {
+            const varAssignStmt = new VarAssignmentStmt("", newStmt);
+            varAssignStmt.lineNumber = newStmt.lineNumber;
+
+            newStmt.loopVar = varAssignStmt;
+
             this.addLoopVariableButtonToToolbox(newStmt);
-            newStmt.scope.references.push(new Reference(newStmt, this.scope));
+            newStmt.scope.references.push(new Reference(varAssignStmt, this.scope));
         }
 
         if (newStmt.getHeight() > 1) this.rebuildBody(newStmt.indexInRoot + 1, curLineNumber + newStmt.getHeight());
@@ -2328,13 +2346,22 @@ export class Module {
 
         try {
             if (code instanceof TypedEmptyExpr) {
-                const parent = code.getParentStatement(); //line that contains "code"
-                if (parent.hasScope()) {
-                    refs.push(...parent.scope.getValidReferences(code.getSelection().startLineNumber));
-                } else {
-                    //code lines at the very top level will not have a body so use Module's scope
-                    refs.push(...this.scope.getValidReferences(code.getSelection().startLineNumber));
+                let scope = code.getParentStatement()?.scope; //line that contains "code"
+                let currRootNode = code.rootNode;
+
+                while(!scope){
+                    if(currRootNode.getParentStatement()?.hasScope()){
+                        scope = currRootNode.getParentStatement().scope;
+                    }
+                    else if(currRootNode.rootNode instanceof Statement){
+                        currRootNode = currRootNode.rootNode;
+                    }
+                    else if(currRootNode.rootNode instanceof Module){
+                        scope = currRootNode.rootNode.scope;
+                    }
                 }
+
+                refs.push(...scope.getValidReferences(code.getSelection().startLineNumber));
 
                 refs = refs.filter(
                     (ref) =>
@@ -3039,6 +3066,7 @@ export class Scope {
         return false;
     }
 
+    
     getValidReferences(line: number): Array<Reference> {
         let validReferences = this.references.filter((ref) => ref.line() < line);
 


### PR DESCRIPTION
**Quick summary of the issue:**

The way scopes work is that they hold the <code>VarAssignmentStmt</code> objects as part of their <code>references</code> array. In the case of a For-Loop, they hold an entire <code>ForStatement</code> object. The issues are:

- For-loops don't currently have a <code>VarAssignmentStmt</code> associated with them that represents their variable. They simply use an <code>IdentifierTkn</code> that is not backed up by an actual variable object. The button in the toolbox does not care for it because it gets passed a Callback with an appropriately set <code>VarReference</code>, but that is a different issue.
- Therefore, when we go to check whether something is a valid reference or not we have no object to represent the variable. 
  - This was fixed by me in a separate commit where I added <code>ForStatements</code> to be treated as <code>VarAssignmentStmt</code> in <code>getValidReferences()</code> of <code>Scope</code>.
- We also cannot easily update the variable's type since there is no object backing it other than the Reference connected to the button in the toolbox.

**Proposed Solution:**
Back the for loop's identifier by a <code>VarAssignmentStmt</code>. 

This will require some updates to update both the reference connected to the toolbox button and the <code>VarAssignmentStmt</code> object within the <code>ForStmt</code>.  However, I see this as worth it since it makes minimal changes to existing functionality. The problem of updating the reference in the button in the toolbox is a separate one and affects all variables and so should be looked at separately. 