### PR TITLE
Decoupled Function Call Expressions from Statements

### DIFF
--- a/src/editor/action-executor.ts
+++ b/src/editor/action-executor.ts
@@ -589,15 +589,11 @@ export class ActionExecutor {
 
             case EditActionType.MoveCursorLeft:
                 preventDefaultEvent = false;
-                // Hole.disableEditableHoleHighlights();
-                // this.module.focus.highlightTextEditableHole();
 
                 break;
 
             case EditActionType.MoveCursorRight:
                 preventDefaultEvent = false;
-                // Hole.disableEditableHoleHighlights();
-                // this.module.focus.highlightTextEditableHole();
 
                 break;
 

--- a/src/editor/action-filter.ts
+++ b/src/editor/action-filter.ts
@@ -1,21 +1,12 @@
 import { Context } from "./focus";
 import { Validator } from "./validator";
-import { Module } from "../syntax-tree/module";
-import { ActionExecutor } from "./action-executor";
-import { DataType, InsertionType } from "../syntax-tree/consts";
-import {
-    BinaryOperatorExpr,
-    EmptyLineStmt,
-    Expression,
-    FunctionCallStmt,
-    Statement,
-    TypedEmptyExpr,
-    VarAssignmentStmt,
-    VariableReferenceExpr,
-} from "../syntax-tree/ast";
-import { Actions, InsertActionType } from "./consts";
-import { Reference } from "../syntax-tree/scope";
 import { EventRouter } from "./event-router";
+import { Module } from "../syntax-tree/module";
+import { Reference } from "../syntax-tree/scope";
+import { ActionExecutor } from "./action-executor";
+import { Actions, InsertActionType } from "./consts";
+import { InsertionType } from "../syntax-tree/consts";
+import { Expression, Statement, TypedEmptyExpr, VarAssignmentStmt } from "../syntax-tree/ast";
 
 export class ActionFilter {
     module: Module;

--- a/src/editor/consts.ts
+++ b/src/editor/consts.ts
@@ -1,4 +1,3 @@
-import { EditAction, InsertActionData } from "./data-types";
 import { BinaryOperator, DataType, UnaryOp } from "../syntax-tree/consts";
 import { EditCodeAction } from "./action-filter";
 import {
@@ -7,6 +6,7 @@ import {
     ElseStatement,
     ExprDotMethodStmt,
     ForStatement,
+    FunctionCallExpr,
     FunctionCallStmt,
     IfStatement,
     ListComma,
@@ -212,7 +212,7 @@ export class Actions {
                 "randint(---, ---)",
                 "add-randint-btn",
                 () =>
-                    new FunctionCallStmt(
+                    new FunctionCallExpr(
                         "randint",
                         [
                             new Argument([DataType.Number], "start", false),
@@ -227,7 +227,7 @@ export class Actions {
                 "range(---)",
                 "add-range-btn",
                 () =>
-                    new FunctionCallStmt(
+                    new FunctionCallExpr(
                         "range",
                         [
                             new Argument([DataType.Number], "start", false),
@@ -242,7 +242,7 @@ export class Actions {
                 "len(---)",
                 "add-len-btn",
                 () =>
-                    new FunctionCallStmt(
+                    new FunctionCallExpr(
                         "len",
                         [
                             new Argument(
@@ -568,7 +568,7 @@ export class Actions {
             new EditCodeAction(
                 "str(---)",
                 "add-cast-str-btn",
-                () => new FunctionCallStmt("str", [new Argument([DataType.Any], "value", false)], DataType.String),
+                () => new FunctionCallExpr("str", [new Argument([DataType.Any], "value", false)], DataType.String),
                 InsertActionType.InsertCastStrExpr
             )
         );

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -26,6 +26,8 @@ export class Focus {
 
     constructor(module: Module) {
         this.module = module;
+
+        this.module.editor.monaco.onDidChangeCursorPosition((e) => this.fireOnNavChangeCallbacks());
     }
 
     subscribeOnNavChangeCallback(callback: (c: Context) => void) {

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -1,6 +1,7 @@
 import { Context } from "./focus";
 import { Module } from "../syntax-tree/module";
 import { Reference } from "../syntax-tree/scope";
+import { VariableController } from "../syntax-tree/variable-controller";
 import { DataType, InsertionType, TAB_SPACES } from "./../syntax-tree/consts";
 import {
     CodeConstruct,
@@ -15,7 +16,6 @@ import {
     TypedEmptyExpr,
     VarAssignmentStmt,
 } from "../syntax-tree/ast";
-import { VariableController } from "../syntax-tree/variable-controller";
 
 export class Validator {
     module: Module;
@@ -275,10 +275,7 @@ export class Validator {
             this.module.focus.onEndOfLine() &&
             !this.module.focus.isTextEditable(providedContext)
         ) {
-            if (context.expressionToLeft != null) {
-                if (context.expressionToLeft?.isStatement()) return true;
-                else return false;
-            }
+            if (context.expressionToLeft != null) return false;
 
             return true;
         }

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -463,7 +463,7 @@ export abstract class Statement implements CodeConstruct {
  * A statement that returns a value such as: binary operators, unary operators, function calls that return a value, literal values, and variables.
  */
 export abstract class Expression extends Statement implements CodeConstruct {
-    rootNode: Statement = null;
+    rootNode: Expression | Statement = null;
     isTextEditable = false;
     addableType: AddableType;
     // TODO: can change this to an Array to enable type checking when returning multiple items


### PR DESCRIPTION
- decoupled function Call expressions from statements
- fixed action-filter bug that didn't show `str()` and `len()` wrapping functions when before them
- fixed fireOnNavChange callback to correctly be called after every navigation change