### PR TITLE
Menu navigation redesign

### DIFF
--- a/src/css/suggestion-menu.css
+++ b/src/css/suggestion-menu.css
@@ -38,7 +38,7 @@
 }
 
 :hover.suggestionOptionParent {
-    background-color: rgba(93, 149, 240, 0.9);
+    background-color: rgba(176, 202, 243, 0.9);
 }
 
 .suggestionOptionText {

--- a/src/css/suggestion-menu.css
+++ b/src/css/suggestion-menu.css
@@ -2,7 +2,6 @@
     display: flex;
     flex-direction: column;
     position: absolute;
-    max-height: 30%;
     width: fit-content;
     max-width: 50%;
     min-width: 2%;
@@ -32,7 +31,6 @@
     cursor: pointer;
 
     height: fit-content;
-    column-gap: 5px;
 
     font-family: Consolas, "Courier New", monospace;
     font-weight: normal;

--- a/src/suggestions/suggestions-controller.ts
+++ b/src/suggestions/suggestions-controller.ts
@@ -32,6 +32,8 @@ class Menu {
     static idPrefix = "suggestion-menu-";
     htmlElement: HTMLDivElement;
 
+    private optionsInViewPort;
+
     constructor(options: Map<string, Function>) {
         this.htmlElement = document.createElement("div");
         this.htmlElement.classList.add(MenuController.menuElementClass);
@@ -228,6 +230,33 @@ class Menu {
     getOptionByText(optionText: string) {
         return this.options.filter((option) => option.text == optionText)[0];
     }
+
+    setOptionsInViewport(n: number) {
+        this.optionsInViewPort = n;
+    }
+
+    getOptionsInViewport() {
+        return this.optionsInViewPort;
+    }
+
+    /**
+     * This should only be called on menus with > 0 options. Otherwise it will have no effect.
+     */
+    updateDimensions() {
+        if (this.options.length > 0) {
+            const optionHeight = this.options[0].htmlElement.offsetHeight;
+            const totalOptionHeight = optionHeight * this.options.length;
+            const vh = window.innerHeight;
+
+            if (totalOptionHeight <= 0.3 * vh) {
+                this.optionsInViewPort = this.options.length;
+                this.htmlElement.style.height = `${totalOptionHeight}px`;
+            } else {
+                this.optionsInViewPort = Math.floor((0.3 * vh) / optionHeight);
+                this.htmlElement.style.height = `${this.optionsInViewPort * optionHeight}px`;
+            }
+        }
+    }
 }
 
 /**
@@ -265,6 +294,7 @@ class MenuOption {
 
         this.htmlElement = document.createElement("div");
         this.htmlElement.classList.add(MenuController.optionElementClass);
+
         this.draftMode = draftMode;
 
         if (draftMode) this.htmlElement.classList.add(MenuController.draftModeOptionElementClass);
@@ -429,6 +459,7 @@ export class MenuController {
         if (this.menus.length > 0) this.removeMenus();
         else if (suggestions.length > 0) {
             const menu = this.module.menuController.buildMenu(suggestions, pos);
+            menu.updateDimensions();
             menu.open();
             this.indexOfRootMenu = 0;
             this.focusedOptionIndex = 0;


### PR DESCRIPTION
Make the behaviour of the suggestion menu more consistent with other editors.

**Changes:**
 - Menu now behaves like a sliding window. Instead of always sliding down or up, it now only does so when the bottom or top boundary is reached.
 - Mouse hover does not call `focusOption()` anymore. It pseudo focuses the option by highlighting it in a different colour (very light blue). If the option is clicked, it will still perform the action associated with it. However, if ENTER is pressed, the option currently selected with the arrow keys (darker blue highlight) will have its action executed.
 - The menu dimensions now depend on the amount of options it has with the max still being ~30vh.