### PR TITLE
Adding import

### DIFF
--- a/src/css/notification.css
+++ b/src/css/notification.css
@@ -63,3 +63,10 @@
 .emph {
     font-weight: 700;
 }
+
+.codeVisual.textBox .button {
+    background-color: #d1d3d6;
+    max-width: 20%;
+    height: 5%;
+    padding: 2px;
+}

--- a/src/css/notification.css
+++ b/src/css/notification.css
@@ -42,6 +42,7 @@
 }
 
 .identifier {
+    color: blueviolet;
     font-weight: bold;
 }
 
@@ -57,4 +58,8 @@
 
 .other {
     font-weight: 600;
+}
+
+.emph {
+    font-weight: 700;
 }

--- a/src/editor/action-executor.ts
+++ b/src/editor/action-executor.ts
@@ -11,7 +11,6 @@ import {
     Expression,
     IdentifierTkn,
     Importable,
-    ImportStatement,
     ListAccessModifier,
     ListLiteralExpression,
     LiteralValExpr,
@@ -1099,36 +1098,7 @@ export class ActionExecutor {
     }
 
     private checkImports(insertedCode: Importable, currentInsertionType: InsertionType): InsertionType {
-        let insertionType = currentInsertionType;
-        let stmtsCount = 0;
-        const checker = (construct: CodeConstruct) => {
-            if (construct instanceof ImportStatement) {
-                stmtsCount++;
-
-                if (
-                    insertedCode instanceof Statement &&
-                    insertedCode.requiredModule !== "" &&
-                    (insertedCode.getKeyword() !== construct.getImportItemName() ||
-                        insertedCode.requiredModule !== construct.getImportModuleName())
-                ) {
-                    console.log(
-                        insertedCode.requiredModule + "-",
-                        insertedCode.getKeyword() + "+",
-                        construct.getImportItemName() + "/",
-                        construct.getImportModuleName() + "*"
-                    );
-                    insertionType = InsertionType.DraftMode;
-                }
-            }
-        };
-
-        this.module.performActionOnBFS(checker);
-
-        if (stmtsCount === 0 && insertedCode.requiredModule !== "") {
-            insertionType = InsertionType.DraftMode;
-        }
-
-        return insertionType;
+        return insertedCode.validateImportOnInsertion(this.module, currentInsertionType);
     }
 
     private openAutocompleteMenu(inserts: EditCodeAction[]) {

--- a/src/editor/action-executor.ts
+++ b/src/editor/action-executor.ts
@@ -11,6 +11,7 @@ import {
     Expression,
     IdentifierTkn,
     Importable,
+    ImportStatement,
     ListAccessModifier,
     ListLiteralExpression,
     LiteralValExpr,
@@ -34,7 +35,7 @@ import { TypeChecker } from "../syntax-tree/type-checker";
 import { isImportable } from "../utilities/util";
 import { BinaryOperator, DataType, InsertionType } from "./../syntax-tree/consts";
 import { EditCodeAction } from "./action-filter";
-import { EditActionType } from "./consts";
+import { EditActionType, InsertActionType } from "./consts";
 import { EditAction } from "./data-types";
 import { Context } from "./focus";
 
@@ -790,6 +791,29 @@ export class ActionExecutor {
                     const items = this.module.removeItems(context.token.rootNode, context.token.indexInRoot - 1, 2);
                     this.module.editor.executeEdits(this.getCascadedBoundary(items), null, "");
                 }
+
+                break;
+            }
+
+            case EditActionType.InsertImportFromDraftMode: {
+                let currContext = context;
+                this.module.editor.monaco.setPosition(new Position(1, 1));
+                this.module.insertEmptyLine();
+                this.module.editor.monaco.setPosition(new Position(1, 1));
+                currContext = this.module.focus.getContext();
+
+                const stmt = new ImportStatement(action.data?.moduleName, action.data?.itemName);
+                const insertAction = new EditCodeAction(
+                    "from --- import --- :",
+                    "add-import-btn",
+                    () => stmt,
+                    InsertActionType.InsertImportStmt,
+                    {},
+                    [" "],
+                    "import",
+                    null
+                );
+                insertAction.performAction(this, this.module.eventRouter, currContext);
 
                 break;
             }

--- a/src/editor/action-executor.ts
+++ b/src/editor/action-executor.ts
@@ -27,13 +27,7 @@ import {
 } from "../syntax-tree/ast";
 import { rebuildBody, replaceInBody } from "../syntax-tree/body";
 import { Callback, CallbackType } from "../syntax-tree/callback";
-import {
-    AutoCompleteType,
-    BuiltInFunctions,
-    MISSING_IMPORT_DRAFT_MODE_STR,
-    PythonKeywords,
-    TAB_SPACES,
-} from "../syntax-tree/consts";
+import { AutoCompleteType, BuiltInFunctions, PythonKeywords, TAB_SPACES } from "../syntax-tree/consts";
 import { Module } from "../syntax-tree/module";
 import { Reference } from "../syntax-tree/scope";
 import { TypeChecker } from "../syntax-tree/type-checker";
@@ -1107,10 +1101,7 @@ export class ActionExecutor {
 
         const insertionType = insertedCode.validateImportOnInsertion(this.module, currentInsertionType);
         if (insertionType === InsertionType.DraftMode && insertedCode instanceof Statement) {
-            this.module.openDraftMode(
-                insertedCode,
-                MISSING_IMPORT_DRAFT_MODE_STR(insertedCode.getKeyword(), insertedCode.requiredModule)
-            );
+            this.module.openImportDraftMode(insertedCode);
         }
     }
 

--- a/src/editor/action-executor.ts
+++ b/src/editor/action-executor.ts
@@ -1109,13 +1109,13 @@ export class ActionExecutor {
                     insertedCode instanceof Statement &&
                     insertedCode.requiredModule !== "" &&
                     (insertedCode.getKeyword() !== construct.getImportItemName() ||
-                        insertedCode.requiredModule !== construct.getImportModule())
+                        insertedCode.requiredModule !== construct.getImportModuleName())
                 ) {
                     console.log(
                         insertedCode.requiredModule + "-",
                         insertedCode.getKeyword() + "+",
                         construct.getImportItemName() + "/",
-                        construct.getImportModule() + "*"
+                        construct.getImportModuleName() + "*"
                     );
                     insertionType = InsertionType.DraftMode;
                 }

--- a/src/editor/consts.ts
+++ b/src/editor/consts.ts
@@ -158,6 +158,7 @@ export enum EditActionType {
     InsertAssignmentModifier,
 
     OpenAutocomplete,
+    InsertImportFromDraftMode,
 }
 
 export enum ConstructName {

--- a/src/editor/consts.ts
+++ b/src/editor/consts.ts
@@ -234,7 +234,10 @@ export class Actions {
                             new Argument([DataType.Number], "start", false),
                             new Argument([DataType.Number], "end", false),
                         ],
-                        DataType.Number
+                        DataType.Number,
+                        null,
+                        null,
+                        "random"
                     ),
                 InsertActionType.InsertRandintExpr,
                 {},

--- a/src/editor/consts.ts
+++ b/src/editor/consts.ts
@@ -8,6 +8,7 @@ import {
     FunctionCallExpr,
     FunctionCallStmt,
     IfStatement,
+    ImportStatement,
     ListAccessModifier,
     ListComma,
     ListLiteralExpression,
@@ -172,6 +173,7 @@ export enum InsertActionType {
     InsertElifStmt,
     InsertElseStmt,
     InsertForStmt,
+    InsertImportStmt,
 
     InsertPrintFunctionStmt,
     InsertRandintExpr,
@@ -597,6 +599,17 @@ export class Actions {
                 {},
                 [" "],
                 "for",
+                null
+            ),
+
+            new EditCodeAction(
+                "from --- import --- :",
+                "add-import-btn",
+                () => new ImportStatement(),
+                InsertActionType.InsertImportStmt,
+                {},
+                [" "],
+                "import",
                 null
             ),
 

--- a/src/editor/draft.ts
+++ b/src/editor/draft.ts
@@ -8,10 +8,10 @@ export class DraftRecord {
 
     private module: Module; //no point in instantiating the editor itself because it will require an instance of Module anyway
 
-    constructor(code: Statement, module: Module) {
+    constructor(code: Statement, module: Module, txt?: string) {
         this.code = code;
         this.module = module;
-        this.module.notificationSystem.addHoverNotification(code, {}, "Draft Mode");
+        this.module.notificationSystem.addHoverNotification(code, {}, txt ?? "");
         this.warning = code.notification;
         this.code.notification = this.warning;
     }

--- a/src/editor/draft.ts
+++ b/src/editor/draft.ts
@@ -1,14 +1,14 @@
 import { HoverNotification } from "../notification-system/notification";
-import { Expression } from "../syntax-tree/ast";
+import { Statement } from "../syntax-tree/ast";
 import { Module } from "../syntax-tree/module";
 
 export class DraftRecord {
-    code: Expression;
+    code: Statement;
     warning: HoverNotification;
 
     private module: Module; //no point in instantiating the editor itself because it will require an instance of Module anyway
 
-    constructor(code: Expression, module: Module) {
+    constructor(code: Statement, module: Module) {
         this.code = code;
         this.module = module;
         this.module.notificationSystem.addHoverNotification(code, {}, "Draft Mode");

--- a/src/editor/event-router.ts
+++ b/src/editor/event-router.ts
@@ -382,6 +382,7 @@ export class EventRouter {
                 break;
             }
 
+            case InsertActionType.InsertImportStmt:
             case InsertActionType.InsertWhileStmt:
             case InsertActionType.InsertIfStmt:
             case InsertActionType.InsertForStmt:

--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -141,7 +141,7 @@ export class Focus {
         this.fireOnNavChangeCallbacks();
     }
 
-    navigatePos(pos: Position) {
+    navigatePos(pos: Position, runNavOffCallbacks: boolean = true) {
         const focusedLineStatement = this.getStatementAtLineNumber(pos.lineNumber);
 
         // clicked at an empty statement => just update focusedStatement
@@ -200,7 +200,7 @@ export class Focus {
 
         const curPos = this.module.editor.monaco.getPosition();
 
-        if (this.prevPosition != null && this.prevPosition.lineNumber != curPos.lineNumber) {
+        if (runNavOffCallbacks && this.prevPosition != null && this.prevPosition.lineNumber != curPos.lineNumber) {
             this.fireOnNavOffCallbacks(
                 this.getStatementAtLineNumber(this.prevPosition.lineNumber),
                 this.getStatementAtLineNumber(curPos.lineNumber)
@@ -221,7 +221,8 @@ export class Focus {
             this.getStatementAtLineNumber(this.module.editor.monaco.getPosition().lineNumber)
         );
 
-        if (curPosition.lineNumber > 1) this.navigatePos(new Position(curPosition.lineNumber - 1, curPosition.column));
+        if (curPosition.lineNumber > 1)
+            this.navigatePos(new Position(curPosition.lineNumber - 1, curPosition.column), false);
         else {
             this.module.editor.monaco.setPosition(new Position(curPosition.lineNumber, 1));
 
@@ -237,7 +238,7 @@ export class Focus {
         this.fireOnNavOffCallbacks(focusedLineStatement, lineBelow);
 
         if (lineBelow != null) {
-            this.navigatePos(new Position(curPosition.lineNumber + 1, curPosition.column));
+            this.navigatePos(new Position(curPosition.lineNumber + 1, curPosition.column), false);
         } else {
             // navigate to the end of current line
             const curLine = this.getStatementAtLineNumber(curPosition.lineNumber);

--- a/src/editor/toolbox.json
+++ b/src/editor/toolbox.json
@@ -1,5 +1,12 @@
 {
     "toolboxConstructGroupOptions": {
+        "imports": {
+            "includeCategory": 1,
+            "categoryDisplayName": "Imports",
+            "includeCategoryItems": {
+                "import": 1
+            }
+        },
         "functionCalls": {
             "includeCategory": 1,
             "categoryDisplayName": "Function Calls",
@@ -290,6 +297,10 @@
         "comptGte": {
             "id": "add-comp-gte-expr-btn",
             "text": "--- >= ---"
+        },
+        "import": {
+            "id": "add-import-btn",
+            "text": "from --- import ---"
         }
     }
 }

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -673,6 +673,8 @@ export class Validator {
                             code,
                             MISSING_IMPORT_DRAFT_MODE_STR(code.getKeyword(), code.requiredModule)
                         );
+
+                        code.notification.addButton(`import ${code.requiredModule}`);
                     }
                 }
             }

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -7,6 +7,7 @@ import {
     EmptyLineStmt,
     IdentifierTkn,
     IfStatement,
+    ImportStatement,
     ListLiteralExpression,
     LiteralValExpr,
     Modifier,
@@ -20,6 +21,7 @@ import {
 import { Module } from "../syntax-tree/module";
 import { Reference } from "../syntax-tree/scope";
 import { VariableController } from "../syntax-tree/variable-controller";
+import { isImportable } from "../utilities/util";
 import { DataType, InsertionType, NumberRegex, TAB_SPACES } from "./../syntax-tree/consts";
 import { EditCodeAction } from "./action-filter";
 import { Context } from "./focus";
@@ -649,5 +651,22 @@ export class Validator {
         const fuse = new Fuse(possibilities, options);
 
         return fuse.search(searchString);
+    }
+
+    validateImports(stmts: ImportStatement[]) {
+        this.module.performActionOnBFS((code: CodeConstruct) => {
+            if (isImportable(code) && code.requiresImport()) {
+                const importStatus = code.validateImportFromImportList(stmts);
+
+                //This check is required otherwise it won't compile. In practice, it will always be a Statement becuase tokens are not importables
+                if (code instanceof Statement) {
+                    if (importStatus && code.draftModeEnabled) {
+                        this.module.closeConstructDraftRecord(code);
+                    } else if (!importStatus && !code.draftModeEnabled) {
+                        this.module.openDraftMode(code);
+                    }
+                }
+            }
+        });
     }
 }

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -22,7 +22,13 @@ import { Module } from "../syntax-tree/module";
 import { Reference } from "../syntax-tree/scope";
 import { VariableController } from "../syntax-tree/variable-controller";
 import { isImportable } from "../utilities/util";
-import { DataType, InsertionType, NumberRegex, TAB_SPACES } from "./../syntax-tree/consts";
+import {
+    DataType,
+    InsertionType,
+    MISSING_IMPORT_DRAFT_MODE_STR,
+    NumberRegex,
+    TAB_SPACES,
+} from "./../syntax-tree/consts";
 import { EditCodeAction } from "./action-filter";
 import { Context } from "./focus";
 
@@ -663,7 +669,10 @@ export class Validator {
                     if (importStatus && code.draftModeEnabled) {
                         this.module.closeConstructDraftRecord(code);
                     } else if (!importStatus && !code.draftModeEnabled) {
-                        this.module.openDraftMode(code);
+                        this.module.openDraftMode(
+                            code,
+                            MISSING_IMPORT_DRAFT_MODE_STR(code.getKeyword(), code.requiredModule)
+                        );
                     }
                 }
             }

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -653,7 +653,10 @@ export class Validator {
         return fuse.search(searchString);
     }
 
-    validateImports(stmts: ImportStatement[]) {
+    validateImports(stmts?: ImportStatement[]) {
+        if (!stmts) {
+            stmts = this.module.getAllImportStmts();
+        }
         this.module.performActionOnBFS((code: CodeConstruct) => {
             if (isImportable(code) && code.requiresImport()) {
                 const importStatus = code.validateImportFromImportList(stmts);

--- a/src/editor/validator.ts
+++ b/src/editor/validator.ts
@@ -22,13 +22,7 @@ import { Module } from "../syntax-tree/module";
 import { Reference } from "../syntax-tree/scope";
 import { VariableController } from "../syntax-tree/variable-controller";
 import { isImportable } from "../utilities/util";
-import {
-    DataType,
-    InsertionType,
-    MISSING_IMPORT_DRAFT_MODE_STR,
-    NumberRegex,
-    TAB_SPACES,
-} from "./../syntax-tree/consts";
+import { DataType, InsertionType, NumberRegex, TAB_SPACES } from "./../syntax-tree/consts";
 import { EditCodeAction } from "./action-filter";
 import { Context } from "./focus";
 
@@ -669,12 +663,7 @@ export class Validator {
                     if (importStatus && code.draftModeEnabled) {
                         this.module.closeConstructDraftRecord(code);
                     } else if (!importStatus && !code.draftModeEnabled) {
-                        this.module.openDraftMode(
-                            code,
-                            MISSING_IMPORT_DRAFT_MODE_STR(code.getKeyword(), code.requiredModule)
-                        );
-
-                        code.notification.addButton(`import ${code.requiredModule}`);
+                        this.module.openImportDraftMode(code);
                     }
                 }
             }

--- a/src/notification-system/notification-system-controller.ts
+++ b/src/notification-system/notification-system-controller.ts
@@ -141,6 +141,10 @@ export class NotificationSystemController {
             this.notifications[code.notification.systemIndex].removeFromDOM();
             this.notifications.splice(code.notification.systemIndex, 1);
             code.notification = null;
+
+            for (const notification of this.notifications) {
+                notification.systemIndex--;
+            }
         } else {
             console.warn("Could not remove notification from construct: " + code);
         }

--- a/src/notification-system/notification.ts
+++ b/src/notification-system/notification.ts
@@ -262,6 +262,8 @@ export class HoverNotification extends Notification {
     private notificationHighlightCollisionCheckInterval = 500;
     private notificationFadeTime = 100;
 
+    private buttons = [];
+
     constructor(
         editor: Editor,
         code: CodeConstruct,
@@ -275,6 +277,17 @@ export class HoverNotification extends Notification {
 
         this.updateMouseOffsets();
         this.scheduleCollisionCheck();
+    }
+
+    addButton(txt: string): HTMLDivElement {
+        const button = document.createElement("div");
+        button.classList.add("button");
+        button.textContent = txt;
+
+        this.domElement.appendChild(button);
+        this.buttons.push(button);
+
+        return button;
     }
 
     protected createDomElement() {

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -861,15 +861,15 @@ export class ElseStatement extends Statement {
 export class ImportStatement extends Statement {
     private moduleNameIndex: number = -1;
     private itemNameIndex: number = -1;
-    constructor(moduleName: string = "   ", itemName: string = "   ") {
+    constructor(moduleName: string = "", itemName: string = "") {
         super();
 
         this.tokens.push(new NonEditableTkn("from ", this, this.tokens.length));
         this.moduleNameIndex = this.tokens.length;
-        this.tokens.push(new EditableTextTkn(moduleName, /[a-zA-Z]/g, this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn(moduleName, new RegExp("^[a-zA-Z]*$"), this, this.tokens.length));
         this.tokens.push(new NonEditableTkn(" import ", this, this.tokens.length));
         this.itemNameIndex = this.tokens.length;
-        this.tokens.push(new EditableTextTkn(itemName, /[a-zA-Z]/g, this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn(itemName, new RegExp("^[a-zA-Z]*$"), this, this.tokens.length));
 
         this.subscribe(
             CallbackType.onFocusOff,

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -902,8 +902,7 @@ export class ImportStatement extends Statement {
         if (this.getImportModuleName() !== "" && this.getImportItemName() !== "") {
             //TODO: Not efficient, but the only way to improve this is to constantly maintain an updated "imported" status
             //on the construct requiring an import, which is tedious so I left it for now. If this ever becomes an issue, that is the solution.
-            const stmts = args.module.getAllImportStmts();
-            args.module.validator.validateImports(stmts);
+            args.module.validator.validateImports();
         }
     }
 

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -895,17 +895,22 @@ export class ImportStatement extends Statement {
         if (this.getImportModuleName() !== "" && this.getImportItemName() !== "") {
             const action = (code: CodeConstruct) => {
                 let closeDraftMode = false;
-                if (code instanceof Statement && isImportable(code) && code.draftModeEnabled) {
+                let openDraftMode = false;
+                if (code instanceof Statement && isImportable(code) && code.requiredModule !== "") {
                     closeDraftMode =
                         code.getKeyword() === this.getImportItemName()
                             ? (code as Importable).requiredModule === this.getImportModuleName()
                                 ? true
                                 : false
                             : false;
+
+                    openDraftMode = !code.draftModeEnabled && !closeDraftMode;
                 }
 
                 if (closeDraftMode) {
                     args.module.closeConstructDraftRecord(code);
+                } else if (openDraftMode) {
+                    args.module.openDraftMode(code);
                 }
             };
 

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -861,15 +861,15 @@ export class ElseStatement extends Statement {
 export class ImportStatement extends Statement {
     private moduleNameIndex: number = -1;
     private itemNameIndex: number = -1;
-    constructor() {
+    constructor(moduleName: string = "   ", itemName: string = "   ") {
         super();
 
         this.tokens.push(new NonEditableTkn("from ", this, this.tokens.length));
         this.moduleNameIndex = this.tokens.length;
-        this.tokens.push(new EditableTextTkn("   ", /[a-zA-Z]/g, this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn(moduleName, /[a-zA-Z]/g, this, this.tokens.length));
         this.tokens.push(new NonEditableTkn(" import ", this, this.tokens.length));
         this.itemNameIndex = this.tokens.length;
-        this.tokens.push(new EditableTextTkn("   ", /[a-zA-Z]/g, this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn(itemName, /[a-zA-Z]/g, this, this.tokens.length));
 
         this.subscribe(
             CallbackType.onFocusOff,
@@ -905,6 +905,14 @@ export class ImportStatement extends Statement {
             const stmts = args.module.getAllImportStmts();
             args.module.validator.validateImports(stmts);
         }
+    }
+
+    setImportModule(txt: string) {
+        (this.tokens[this.moduleNameIndex] as EditableTextTkn).setEditedText(txt);
+    }
+
+    setImportItem(txt: string) {
+        (this.tokens[this.itemNameIndex] as EditableTextTkn).setEditedText(txt);
     }
 
     private onDelete(module: Module) {

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -23,7 +23,7 @@ import {
     NumberRegex,
     StringRegex,
     TAB_SPACES,
-    UnaryOp
+    UnaryOp,
 } from "./consts";
 import { Module } from "./module";
 import { Scope } from "./scope";
@@ -855,6 +855,22 @@ export class ElseStatement extends Statement {
                   validator.canInsertElseStmtAtPrevIndent(providedContext))
             ? InsertionType.Valid
             : InsertionType.Invalid;
+    }
+}
+
+export class ImportStatement extends Statement {
+    constructor() {
+        super();
+
+        this.tokens.push(new NonEditableTkn("from ", this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn("   ", /[a-zA-Z]/g, this, this.tokens.length));
+        this.tokens.push(new NonEditableTkn(" import ", this, this.tokens.length));
+        this.tokens.push(new EditableTextTkn("   ", /[a-zA-Z]/g, this, this.tokens.length));
+    }
+
+    validateContext(validator: Validator, providedContext: Context): InsertionType {
+        //TODO: This is the same for most Statements so should probably move this functionality into the parent class
+        return validator.onEmptyLine(providedContext) ? InsertionType.Valid : InsertionType.Invalid;
     }
 }
 

--- a/src/syntax-tree/consts.ts
+++ b/src/syntax-tree/consts.ts
@@ -1,3 +1,5 @@
+import { CSSClasses, TextEnhance } from "../utilities/text-enhance";
+
 export const TAB_SPACES = 4;
 
 export enum InsertionType {
@@ -234,3 +236,17 @@ export enum AutoCompleteType {
 export const IdentifierRegex = RegExp("^[^\\d\\W]\\w*$");
 export const NumberRegex = RegExp("^(([+-][0-9]+)|(([+-][0-9]*)\\.([0-9]+))|([0-9]*)|(([0-9]*)\\.([0-9]*)))$");
 export const StringRegex = RegExp('^([^\\r\\n\\"]*)$');
+
+export const MISSING_IMPORT_DRAFT_MODE_STR = (requiredItem, requiredModule) => {
+    const te = new TextEnhance();
+    return (
+        te.getStyledSpan(requiredItem, CSSClasses.identifier) +
+        " does not exist in this program. It is part of the " +
+        te.getStyledSpan(requiredModule, CSSClasses.emphasize) +
+        " module. " +
+        te.getStyledSpan(requiredModule, CSSClasses.emphasize) +
+        " has to be imported before " +
+        te.getStyledSpan(requiredItem, CSSClasses.identifier) +
+        " can be used."
+    );
+};

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -626,8 +626,7 @@ export class Module {
                     this.focus.getContext()
                 );
 
-                const stmts = this.getAllImportStmts();
-                this.validator.validateImports(stmts);
+                this.validator.validateImports();
             }).bind(this)
         );
     }

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -20,6 +20,7 @@ import {
     EmptyLineStmt,
     Expression,
     ForStatement,
+    ImportStatement,
     ListLiteralExpression,
     Statement,
     Token,
@@ -594,5 +595,17 @@ export class Module {
 
             duringAction(curr);
         }
+    }
+
+    getAllImportStmts(): ImportStatement[] {
+        const stmts: ImportStatement[] = [];
+
+        this.performActionOnBFS((code: CodeConstruct) => {
+            if (code instanceof ImportStatement) {
+                stmts.push(code);
+            }
+        });
+
+        return stmts;
     }
 }

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -1,7 +1,8 @@
 import { Position, Range } from "monaco-editor";
 import { ActionExecutor } from "../editor/action-executor";
 import { ActionFilter } from "../editor/action-filter";
-import { CodeStatus } from "../editor/consts";
+import { CodeStatus, EditActionType } from "../editor/consts";
+import { EditAction } from "../editor/data-types";
 import { DraftRecord } from "../editor/draft";
 import { Editor } from "../editor/editor";
 import { EventRouter } from "../editor/event-router";
@@ -613,6 +614,21 @@ export class Module {
     openImportDraftMode(code: Statement & Importable) {
         this.openDraftMode(code, MISSING_IMPORT_DRAFT_MODE_STR(code.getKeyword(), code.requiredModule));
 
-        code.notification.addButton(`import ${code.requiredModule}`);
+        const button = code.notification.addButton(`import ${code.requiredModule}`);
+        button.addEventListener(
+            "click",
+            (() => {
+                this.executer.execute(
+                    new EditAction(EditActionType.InsertImportFromDraftMode, {
+                        moduleName: code.requiredModule,
+                        itemName: code.getKeyword(),
+                    }),
+                    this.focus.getContext()
+                );
+
+                const stmts = this.getAllImportStmts();
+                this.validator.validateImports(stmts);
+            }).bind(this)
+        );
     }
 }

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -521,9 +521,9 @@ export class Module {
         }
     }
 
-    openDraftMode(code: Statement) {
+    openDraftMode(code: Statement, txt: string = "Draft Mode Placeholder Txt") {
         code.draftModeEnabled = true;
-        this.draftExpressions.push(new DraftRecord(code, this));
+        this.draftExpressions.push(new DraftRecord(code, this, txt));
         code.draftRecord = this.draftExpressions[this.draftExpressions.length - 1];
     }
 

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -520,7 +520,7 @@ export class Module {
         }
     }
 
-    openDraftMode(code: Expression) {
+    openDraftMode(code: Statement) {
         code.draftModeEnabled = true;
         this.draftExpressions.push(new DraftRecord(code, this));
         code.draftRecord = this.draftExpressions[this.draftExpressions.length - 1];
@@ -572,5 +572,27 @@ export class Module {
         }
 
         return ret ?? CodeStatus.Runnable;
+    }
+
+    performActionOnBFS(duringAction: (code: CodeConstruct) => void) {
+        const Q: CodeConstruct[] = [];
+        Q.push(...this.body);
+
+        while (Q.length > 0) {
+            let curr: CodeConstruct = Q.splice(0, 1)[0];
+
+            if (curr instanceof Expression && curr.tokens.length > 0) {
+                Q.push(...curr.tokens);
+            } else if (curr instanceof Statement) {
+                for (const tkn of curr.tokens) {
+                    Q.push(tkn);
+                }
+                if (curr.body.length > 0) {
+                    Q.push(...curr.body);
+                }
+            }
+
+            duringAction(curr);
+        }
     }
 }

--- a/src/syntax-tree/module.ts
+++ b/src/syntax-tree/module.ts
@@ -20,6 +20,7 @@ import {
     EmptyLineStmt,
     Expression,
     ForStatement,
+    Importable,
     ImportStatement,
     ListLiteralExpression,
     Statement,
@@ -30,7 +31,7 @@ import {
 } from "./ast";
 import { rebuildBody } from "./body";
 import { CallbackType } from "./callback";
-import { DataType, TAB_SPACES } from "./consts";
+import { DataType, MISSING_IMPORT_DRAFT_MODE_STR, TAB_SPACES } from "./consts";
 import { Reference, Scope } from "./scope";
 import { TypeChecker } from "./type-checker";
 import { VariableController } from "./variable-controller";
@@ -607,5 +608,11 @@ export class Module {
         });
 
         return stmts;
+    }
+
+    openImportDraftMode(code: Statement & Importable) {
+        this.openDraftMode(code, MISSING_IMPORT_DRAFT_MODE_STR(code.getKeyword(), code.requiredModule));
+
+        code.notification.addButton(`import ${code.requiredModule}`);
     }
 }

--- a/src/utilities/text-enhance.ts
+++ b/src/utilities/text-enhance.ts
@@ -2,6 +2,7 @@ export enum CSSClasses {
     identifier = "identifier",
     type = "type",
     keyword = "keyword",
+    emphasize = "emph",
     other = "other",
 }
 

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -1,4 +1,5 @@
 import { ConstructDoc } from "../suggestions/construct-doc";
+import { Importable } from "../syntax-tree/ast";
 import { Module } from "../syntax-tree/module";
 import { DataType, ListTypes } from "./../syntax-tree/consts";
 
@@ -133,4 +134,8 @@ export function hasMatchWithIndex<T>(list1: T[], list2: T[]): [number, number] {
     }
 
     return matchingIndices;
+}
+
+export function isImportable(object: unknown): object is Importable {
+    return Object.prototype.hasOwnProperty.call(object, "requiredModule"); //calling hasOwnProperty with call() because 'object' is not necessarily an object
 }


### PR DESCRIPTION
Added behaviours
-
- Added new `ImportStatement` construct and logic for inserting it, modifying and deleting it.
    - Imports follow the following Python format `from --- import ---` so each construct has to be individually imported.
- Added new `Importable` interface which will connect together all constructs (functions and constants) that require imports.
- Inserting a code construct that would usually require an import now enters draft mode if the import statement for it is missing.
- Importing the correct construct clears all draft modes that were triggered by the missing import.
- Changes or removals of imports will revalidate imports and highlight any construct that is now missing its required import.
- Draft modes triggered by missing imports have help text.
- Draft modes triggered by missing imports have a button for adding the required import to the code.
- Fixed issue with notifications not decrementing their system index when a notification is removed from the global array.

Known Issues:
-
- #361 
- #326 
