### PR TITLE
Fix mouse offset calculation for draft mode collisions

### DIFF
--- a/src/notification-system/notification.ts
+++ b/src/notification-system/notification.ts
@@ -387,7 +387,7 @@ export class HoverNotification extends Notification {
 
         //TODO: This top margin is inconsistent for some reason. Sometimes it is there sometimes it is not, which will make this calculation
         //wrong from time to time...
-        this.mouseTopOffset = parseFloat(window.getComputedStyle(document.getElementById(EDITOR_DOM_ID)).paddingTop);
+        this.mouseTopOffset = parseFloat(window.getComputedStyle(document.getElementById("editorArea")).paddingTop);
     }
 
     private scheduleCollisionCheck() {


### PR DESCRIPTION
This was not a problem with the collision box. It was in the correct place. In fact, the highlights position and dimensions are used for that so if the highlight is visually in the correct place, so is the collision box. `mouseTopOffset` was being assigned the wrong value due to some DOM structure changes that were made earlier.

I have outlined problems with the hover in the Known Architectural Issues. It is like an FAQ so that if we decide to try again to improve it, we don't try the same things (which don't work) twice.