### PR TITLE
Issue 368

### DIFF
--- a/src/editor/focus.ts
+++ b/src/editor/focus.ts
@@ -215,11 +215,9 @@ export class Focus {
     navigateUp() {
         const curPosition = this.module.editor.monaco.getPosition();
         const focusedLineStatement = this.getStatementAtLineNumber(curPosition.lineNumber);
+        const lineAbove = this.getStatementAtLineNumber(curPosition.lineNumber - 1);
 
-        this.fireOnNavOffCallbacks(
-            focusedLineStatement,
-            this.getStatementAtLineNumber(this.module.editor.monaco.getPosition().lineNumber)
-        );
+        this.fireOnNavOffCallbacks(focusedLineStatement, lineAbove);
 
         if (curPosition.lineNumber > 1)
             this.navigatePos(new Position(curPosition.lineNumber - 1, curPosition.column), false);

--- a/src/syntax-tree/ast.ts
+++ b/src/syntax-tree/ast.ts
@@ -1873,10 +1873,12 @@ export class FunctionCallExpr extends Expression implements Importable {
         let insertionType = currentInsertionType;
         let importsOfThisConstruct: ImportStatement[] = [];
         const checker = (construct: CodeConstruct, stmts: ImportStatement[]) => {
-            if (construct instanceof ImportStatement) {
-                if (this.requiredModule === construct.getImportModuleName()) {
-                    stmts.push(construct);
-                }
+            if (
+                construct instanceof ImportStatement &&
+                this.getLineNumber() > construct.getLineNumber() &&
+                this.requiredModule === construct.getImportModuleName()
+            ) {
+                stmts.push(construct);
             }
         };
 
@@ -1897,7 +1899,9 @@ export class FunctionCallExpr extends Expression implements Importable {
     }
 
     validateImportFromImportList(imports: ImportStatement[]): boolean {
-        const relevantImports = imports.filter((stmt) => stmt.getImportModuleName() === this.requiredModule);
+        const relevantImports = imports.filter(
+            (stmt) => stmt.getImportModuleName() === this.requiredModule && this.getLineNumber() > stmt.getLineNumber()
+        );
 
         if (relevantImports.length === 0) {
             return false;
@@ -1989,10 +1993,12 @@ export class FunctionCallStmt extends Statement implements Importable {
         let insertionType = currentInsertionType;
         let importsOfThisConstruct: ImportStatement[] = [];
         const checker = (construct: CodeConstruct, stmts: ImportStatement[]) => {
-            if (construct instanceof ImportStatement) {
-                if (this.requiredModule === construct.getImportModuleName()) {
-                    stmts.push(construct);
-                }
+            if (
+                construct instanceof ImportStatement &&
+                this.getLineNumber() > construct.getLineNumber() &&
+                this.requiredModule === construct.getImportModuleName()
+            ) {
+                stmts.push(construct);
             }
         };
 
@@ -2013,8 +2019,10 @@ export class FunctionCallStmt extends Statement implements Importable {
     }
 
     validateImportFromImportList(imports: ImportStatement[]): boolean {
-        const relevantImports = imports.filter((stmt) => stmt.getImportModuleName() === this.requiredModule);
-        console.log(relevantImports);
+        const relevantImports = imports.filter(
+            (stmt) => stmt.getImportModuleName() === this.requiredModule && this.getLineNumber() > stmt.getLineNumber()
+        );
+
         if (relevantImports.length === 0) {
             return false;
         }


### PR DESCRIPTION
- Fix issue with import statement validation ignoring location of the statement in the code
- Fix issue with `navigateUp()` using an incorrect line for `navOffCallbacks` which prevented some validation from triggering on upwards navigation. 